### PR TITLE
Adjust the Prometheus-Grafana dashboard for multiple servers

### DIFF
--- a/visualization/grafana-dashboards/App.Metrics.Sandbox-Prometheus-GenericWeb.json
+++ b/visualization/grafana-dashboards/App.Metrics.Sandbox-Prometheus-GenericWeb.json
@@ -1,2760 +1,2830 @@
 {
-    "annotations": {
-        "list": []
-    },
-    "description": "Dashboard to visualize metrics captured by App Metrics ASP.NET Core Middleware -https://github.com/alhardy/AppMetrics",
-    "editable": true,
-    "gnetId": 2204,
-    "graphTooltip": 1,
-    "hideControls": false,
-    "id": 24,
-    "links": [],
-    "refresh": "5s",
-    "rows": [
+  "annotations": {
+    "list": []
+  },
+  "description": "Dashboard to visualize metrics captured by App Metrics ASP.NET Core Middleware 1.2.0, tested with App.Metrics.Formatters.Prometheus 1.1.0  - http://app-metrics.io/",
+  "editable": true,
+  "gnetId": 2204,
+  "graphTooltip": 1,
+  "hideControls": false,
+  "id": 68,
+  "links": [],
+  "refresh": "5s",
+  "rows": [
+    {
+      "collapse": false,
+      "height": "250",
+      "panels": [
         {
-            "collapse": false,
-            "height": "250",
-            "panels": [
-                {
-                    "cacheTimeout": null,
-                    "colorBackground": false,
-                    "colorValue": false,
-                    "colors": [
-                        "rgba(245, 54, 54, 0.9)",
-                        "rgba(237, 129, 40, 0.89)",
-                        "rgba(50, 172, 45, 0.97)"
-                    ],
-                    "datasource": "$datasource",
-                    "editable": true,
-                    "error": false,
-                    "format": "rpm",
-                    "gauge": {
-                        "maxValue": 100,
-                        "minValue": 0,
-                        "show": false,
-                        "thresholdLabels": false,
-                        "thresholdMarkers": true
-                    },
-                    "id": 8,
-                    "interval": "",
-                    "links": [],
-                    "mappingType": 1,
-                    "mappingTypes": [
-                        {
-                            "name": "value to text",
-                            "value": 1
-                        },
-                        {
-                            "name": "range to text",
-                            "value": 2
-                        }
-                    ],
-                    "maxDataPoints": 100,
-                    "nullPointMode": "connected",
-                    "nullText": null,
-                    "postfix": "",
-                    "postfixFontSize": "50%",
-                    "prefix": "",
-                    "prefixFontSize": "50%",
-                    "rangeMaps": [
-                        {
-                            "from": "null",
-                            "text": "N/A",
-                            "to": "null"
-                        }
-                    ],
-                    "span": 2,
-                    "sparkline": {
-                        "fillColor": "rgba(31, 118, 189, 0.18)",
-                        "full": true,
-                        "lineColor": "rgb(31, 120, 193)",
-                        "show": true
-                    },
-                    "targets": [
-                        {
-                            "dsType": "influxdb",
-                            "expr": "rate(application_httprequests_transactions_count{env=\"$environment\",app=\"$application\",server=\"$server\"}[1m])*60",
-                            "groupBy": [
-                                {
-                                    "params": [
-                                        "$interval"
-                                    ],
-                                    "type": "time"
-                                },
-                                {
-                                    "params": [
-                                        "null"
-                                    ],
-                                    "type": "fill"
-                                }
-                            ],
-                            "intervalFactor": 1,
-                            "measurement": "application.httprequests__transactions",
-                            "metric": "",
-                            "policy": "default",
-                            "refId": "A",
-                            "resultFormat": "time_series",
-                            "select": [
-                                [
-                                    {
-                                        "params": [
-                                            "rate1m"
-                                        ],
-                                        "type": "field"
-                                    },
-                                    {
-                                        "params": [],
-                                        "type": "last"
-                                    }
-                                ]
-                            ],
-                            "step": 2,
-                            "tags": [
-                                {
-                                    "key": "app",
-                                    "operator": "=~",
-                                    "value": "/^$application$/"
-                                },
-                                {
-                                    "condition": "AND",
-                                    "key": "env",
-                                    "operator": "=~",
-                                    "value": "/^$environment$/"
-                                }
-                            ]
-                        }
-                    ],
-                    "thresholds": "",
-                    "title": "Throughput",
-                    "type": "singlestat",
-                    "valueFontSize": "80%",
-                    "valueMaps": [
-                        {
-                            "op": "=",
-                            "text": "N/A",
-                            "value": "null"
-                        }
-                    ],
-                    "valueName": "current"
-                },
-                {
-                    "cacheTimeout": null,
-                    "colorBackground": false,
-                    "colorValue": false,
-                    "colors": [
-                        "rgba(50, 172, 45, 0.97)",
-                        "rgba(237, 129, 40, 0.89)",
-                        "rgba(245, 54, 54, 0.9)"
-                    ],
-                    "datasource": "$datasource",
-                    "decimals": 4,
-                    "editable": true,
-                    "error": false,
-                    "format": "percent",
-                    "gauge": {
-                        "maxValue": 100,
-                        "minValue": 0,
-                        "show": false,
-                        "thresholdLabels": false,
-                        "thresholdMarkers": true
-                    },
-                    "id": 6,
-                    "interval": null,
-                    "links": [],
-                    "mappingType": 1,
-                    "mappingTypes": [
-                        {
-                            "name": "value to text",
-                            "value": 1
-                        },
-                        {
-                            "name": "range to text",
-                            "value": 2
-                        }
-                    ],
-                    "maxDataPoints": 100,
-                    "nullPointMode": "connected",
-                    "nullText": null,
-                    "postfix": "",
-                    "postfixFontSize": "50%",
-                    "prefix": "",
-                    "prefixFontSize": "50%",
-                    "rangeMaps": [
-                        {
-                            "from": "",
-                            "text": "",
-                            "to": ""
-                        }
-                    ],
-                    "span": 2,
-                    "sparkline": {
-                        "fillColor": "rgba(31, 118, 189, 0.18)",
-                        "full": true,
-                        "lineColor": "rgb(31, 120, 193)",
-                        "show": true
-                    },
-                    "targets": [
-                        {
-                            "dsType": "influxdb",
-                            "expr": "application_httprequests_one_minute_error_percentage_rate{env=\"$environment\",app=\"$application\",server=\"$server\"}",
-                            "groupBy": [],
-                            "intervalFactor": 2,
-                            "measurement": "application.httprequests__one_minute_error_percentage_rate",
-                            "policy": "default",
-                            "query": "SELECT  \"value\" FROM \"application.httprequests__percentage_error_requests\" WHERE $timeFilter",
-                            "rawQuery": false,
-                            "refId": "A",
-                            "resultFormat": "time_series",
-                            "select": [
-                                [
-                                    {
-                                        "params": [
-                                            "value"
-                                        ],
-                                        "type": "field"
-                                    }
-                                ]
-                            ],
-                            "step": 4,
-                            "tags": [
-                                {
-                                    "key": "env",
-                                    "operator": "=~",
-                                    "value": "/^$environment$/"
-                                },
-                                {
-                                    "condition": "AND",
-                                    "key": "app",
-                                    "operator": "=~",
-                                    "value": "/^$application$/"
-                                }
-                            ]
-                        }
-                    ],
-                    "thresholds": "",
-                    "title": "Error %",
-                    "type": "singlestat",
-                    "valueFontSize": "80%",
-                    "valueMaps": [
-                        {
-                            "op": "=",
-                            "text": "0%",
-                            "value": "null"
-                        }
-                    ],
-                    "valueName": "current"
-                },
-                {
-                    "aliasColors": {},
-                    "bars": false,
-                    "datasource": "$datasource",
-                    "editable": true,
-                    "error": false,
-                    "fill": 2,
-                    "id": 13,
-                    "interval": "$summarize",
-                    "legend": {
-                        "avg": false,
-                        "current": false,
-                        "max": false,
-                        "min": false,
-                        "show": false,
-                        "total": false,
-                        "values": false
-                    },
-                    "lines": true,
-                    "linewidth": 1,
-                    "links": [],
-                    "nullPointMode": "connected",
-                    "percentage": false,
-                    "pointradius": 5,
-                    "points": false,
-                    "renderer": "flot",
-                    "seriesOverrides": [],
-                    "span": 4,
-                    "stack": false,
-                    "steppedLine": false,
-                    "targets": [
-                        {
-                            "alias": "",
-                            "dsType": "influxdb",
-                            "expr": "application_httprequests_active{env=\"$environment\",app=\"$application\",server=\"$server\"}",
-                            "groupBy": [
-                                {
-                                    "params": [
-                                        "$interval"
-                                    ],
-                                    "type": "time"
-                                },
-                                {
-                                    "params": [
-                                        "null"
-                                    ],
-                                    "type": "fill"
-                                }
-                            ],
-                            "intervalFactor": 2,
-                            "measurement": "application.httprequests__active",
-                            "policy": "default",
-                            "refId": "A",
-                            "resultFormat": "time_series",
-                            "select": [
-                                [
-                                    {
-                                        "params": [
-                                            "value"
-                                        ],
-                                        "type": "field"
-                                    },
-                                    {
-                                        "params": [],
-                                        "type": "last"
-                                    }
-                                ]
-                            ],
-                            "step": 10,
-                            "tags": [
-                                {
-                                    "key": "env",
-                                    "operator": "=~",
-                                    "value": "/^$environment$/"
-                                },
-                                {
-                                    "condition": "AND",
-                                    "key": "app",
-                                    "operator": "=~",
-                                    "value": "/^$application$/"
-                                }
-                            ]
-                        }
-                    ],
-                    "thresholds": [],
-                    "timeFrom": null,
-                    "timeShift": null,
-                    "title": "Active Requests",
-                    "tooltip": {
-                        "msResolution": false,
-                        "shared": true,
-                        "sort": 0,
-                        "value_type": "individual"
-                    },
-                    "type": "graph",
-                    "xaxis": {
-                        "mode": "time",
-                        "name": null,
-                        "show": true,
-                        "values": []
-                    },
-                    "yaxes": [
-                        {
-                            "format": "short",
-                            "label": null,
-                            "logBase": 1,
-                            "max": null,
-                            "min": null,
-                            "show": true
-                        },
-                        {
-                            "format": "short",
-                            "label": null,
-                            "logBase": 1,
-                            "max": null,
-                            "min": null,
-                            "show": true
-                        }
-                    ]
-                },
-                {
-                    "aliasColors": {
-                        "application.httprequests__apdex.last": "#6ED0E0"
-                    },
-                    "bars": false,
-                    "datasource": "$datasource",
-                    "editable": true,
-                    "error": false,
-                    "fill": 1,
-                    "height": "",
-                    "id": 7,
-                    "interval": "$summarize",
-                    "legend": {
-                        "avg": false,
-                        "current": false,
-                        "max": false,
-                        "min": false,
-                        "show": false,
-                        "total": false,
-                        "values": false
-                    },
-                    "lines": true,
-                    "linewidth": 3,
-                    "links": [],
-                    "nullPointMode": "connected",
-                    "percentage": false,
-                    "pointradius": 5,
-                    "points": false,
-                    "renderer": "flot",
-                    "seriesOverrides": [],
-                    "span": 4,
-                    "stack": false,
-                    "steppedLine": false,
-                    "targets": [
-                        {
-                            "dsType": "influxdb",
-                            "expr": "application_httprequests_apdex{env=\"stage\",app=\"$application\",server=\"$server\"}",
-                            "groupBy": [
-                                {
-                                    "params": [
-                                        "$interval"
-                                    ],
-                                    "type": "time"
-                                },
-                                {
-                                    "params": [
-                                        "null"
-                                    ],
-                                    "type": "fill"
-                                }
-                            ],
-                            "intervalFactor": 2,
-                            "measurement": "application.httprequests__apdex",
-                            "metric": "application_httprequests_apdex",
-                            "policy": "default",
-                            "refId": "A",
-                            "resultFormat": "time_series",
-                            "select": [
-                                [
-                                    {
-                                        "params": [
-                                            "score"
-                                        ],
-                                        "type": "field"
-                                    },
-                                    {
-                                        "params": [],
-                                        "type": "last"
-                                    }
-                                ]
-                            ],
-                            "step": 10,
-                            "tags": [
-                                {
-                                    "key": "app",
-                                    "operator": "=~",
-                                    "value": "/^$application$/"
-                                },
-                                {
-                                    "condition": "AND",
-                                    "key": "env",
-                                    "operator": "=~",
-                                    "value": "/^$environment$/"
-                                }
-                            ]
-                        }
-                    ],
-                    "thresholds": [
-                        {
-                            "colorMode": "critical",
-                            "fill": true,
-                            "line": true,
-                            "op": "lt",
-                            "value": 0.5
-                        },
-                        {
-                            "colorMode": "warning",
-                            "fill": true,
-                            "line": true,
-                            "op": "gt",
-                            "value": 0.5
-                        },
-                        {
-                            "colorMode": "ok",
-                            "fill": true,
-                            "line": true,
-                            "op": "gt",
-                            "value": 0.75
-                        }
-                    ],
-                    "timeFrom": null,
-                    "timeShift": null,
-                    "title": "Apdex score",
-                    "tooltip": {
-                        "msResolution": false,
-                        "shared": true,
-                        "sort": 0,
-                        "value_type": "individual"
-                    },
-                    "type": "graph",
-                    "xaxis": {
-                        "mode": "time",
-                        "name": null,
-                        "show": true,
-                        "values": []
-                    },
-                    "yaxes": [
-                        {
-                            "format": "short",
-                            "label": "apdex",
-                            "logBase": 1,
-                            "max": "1",
-                            "min": "0",
-                            "show": true
-                        },
-                        {
-                            "format": "short",
-                            "label": null,
-                            "logBase": 1,
-                            "max": null,
-                            "min": null,
-                            "show": false
-                        }
-                    ]
-                },
-                {
-                    "aliasColors": {},
-                    "bars": false,
-                    "datasource": "$datasource",
-                    "editable": true,
-                    "error": false,
-                    "fill": 1,
-                    "height": "350",
-                    "id": 1,
-                    "interval": "$summarize",
-                    "legend": {
-                        "avg": false,
-                        "current": true,
-                        "max": false,
-                        "min": false,
-                        "show": true,
-                        "total": false,
-                        "values": true
-                    },
-                    "lines": true,
-                    "linewidth": 1,
-                    "links": [],
-                    "nullPointMode": "connected",
-                    "percentage": false,
-                    "pointradius": 5,
-                    "points": false,
-                    "renderer": "flot",
-                    "seriesOverrides": [],
-                    "span": 6,
-                    "stack": false,
-                    "steppedLine": false,
-                    "targets": [
-                        {
-                            "alias": "$col",
-                            "dsType": "influxdb",
-                            "expr": "rate(application_httprequests_transactions_count{env=\"$environment\",app=\"$application\",server=\"$server\"}[1m])*60",
-                            "groupBy": [
-                                {
-                                    "params": [
-                                        "$interval"
-                                    ],
-                                    "type": "time"
-                                },
-                                {
-                                    "params": [
-                                        "null"
-                                    ],
-                                    "type": "fill"
-                                }
-                            ],
-                            "intervalFactor": 2,
-                            "legendFormat": "1 min rate",
-                            "measurement": "application.httprequests__transactions",
-                            "policy": "default",
-                            "refId": "A",
-                            "resultFormat": "time_series",
-                            "select": [
-                                [
-                                    {
-                                        "params": [
-                                            "rate1m"
-                                        ],
-                                        "type": "field"
-                                    },
-                                    {
-                                        "params": [],
-                                        "type": "last"
-                                    },
-                                    {
-                                        "params": [
-                                            "1 min rate"
-                                        ],
-                                        "type": "alias"
-                                    }
-                                ],
-                                [
-                                    {
-                                        "params": [
-                                            "rate5m"
-                                        ],
-                                        "type": "field"
-                                    },
-                                    {
-                                        "params": [],
-                                        "type": "last"
-                                    },
-                                    {
-                                        "params": [
-                                            "5 min rate"
-                                        ],
-                                        "type": "alias"
-                                    }
-                                ],
-                                [
-                                    {
-                                        "params": [
-                                            "rate15m"
-                                        ],
-                                        "type": "field"
-                                    },
-                                    {
-                                        "params": [],
-                                        "type": "last"
-                                    },
-                                    {
-                                        "params": [
-                                            "15 min rate"
-                                        ],
-                                        "type": "alias"
-                                    }
-                                ]
-                            ],
-                            "step": 10,
-                            "tags": [
-                                {
-                                    "key": "env",
-                                    "operator": "=~",
-                                    "value": "/^$environment$/"
-                                },
-                                {
-                                    "condition": "AND",
-                                    "key": "app",
-                                    "operator": "=~",
-                                    "value": "/^$application$/"
-                                }
-                            ]
-                        },
-                        {
-                            "expr": "rate(application_httprequests_transactions_count{env=\"$environment\",app=\"$application\",server=\"$server\"}[5m])*60",
-                            "intervalFactor": 2,
-                            "legendFormat": "5 min rate",
-                            "refId": "B",
-                            "step": 10
-                        },
-                        {
-                            "expr": "rate(application_httprequests_transactions_count{env=\"$environment\",app=\"$application\",server=\"$server\"}[15m])*60",
-                            "intervalFactor": 2,
-                            "legendFormat": "15 min rate",
-                            "refId": "C",
-                            "step": 10
-                        }
-                    ],
-                    "thresholds": [],
-                    "timeFrom": null,
-                    "timeShift": null,
-                    "title": "Throughput",
-                    "tooltip": {
-                        "msResolution": false,
-                        "shared": true,
-                        "sort": 0,
-                        "value_type": "individual"
-                    },
-                    "type": "graph",
-                    "xaxis": {
-                        "mode": "time",
-                        "name": null,
-                        "show": true,
-                        "values": []
-                    },
-                    "yaxes": [
-                        {
-                            "format": "rpm",
-                            "label": null,
-                            "logBase": 1,
-                            "max": null,
-                            "min": null,
-                            "show": true
-                        },
-                        {
-                            "format": "short",
-                            "label": null,
-                            "logBase": 1,
-                            "max": null,
-                            "min": null,
-                            "show": true
-                        }
-                    ]
-                },
-                {
-                    "aliasColors": {},
-                    "bars": false,
-                    "datasource": "$datasource",
-                    "editable": true,
-                    "error": false,
-                    "fill": 1,
-                    "height": "350",
-                    "id": 2,
-                    "interval": "$summarize",
-                    "legend": {
-                        "alignAsTable": false,
-                        "avg": false,
-                        "current": false,
-                        "max": false,
-                        "min": false,
-                        "rightSide": false,
-                        "show": true,
-                        "total": false,
-                        "values": false
-                    },
-                    "lines": true,
-                    "linewidth": 1,
-                    "links": [],
-                    "nullPointMode": "connected",
-                    "percentage": false,
-                    "pointradius": 5,
-                    "points": false,
-                    "renderer": "flot",
-                    "seriesOverrides": [],
-                    "span": 6,
-                    "stack": false,
-                    "steppedLine": false,
-                    "targets": [
-                        {
-                            "alias": "$col",
-                            "dsType": "influxdb",
-                            "expr": "application_httprequests_transactions{env=\"$environment\",app=\"$application\",server=\"$server\",quantile=\"0.75\"}",
-                            "groupBy": [
-                                {
-                                    "params": [
-                                        "$interval"
-                                    ],
-                                    "type": "time"
-                                },
-                                {
-                                    "params": [
-                                        "null"
-                                    ],
-                                    "type": "fill"
-                                }
-                            ],
-                            "intervalFactor": 2,
-                            "legendFormat": "75th Percentile",
-                            "measurement": "application.httprequests__transactions",
-                            "metric": "",
-                            "policy": "default",
-                            "refId": "A",
-                            "resultFormat": "time_series",
-                            "select": [
-                                [
-                                    {
-                                        "params": [
-                                            "p95"
-                                        ],
-                                        "type": "field"
-                                    },
-                                    {
-                                        "params": [],
-                                        "type": "last"
-                                    },
-                                    {
-                                        "params": [
-                                            "95th Percentile"
-                                        ],
-                                        "type": "alias"
-                                    }
-                                ],
-                                [
-                                    {
-                                        "params": [
-                                            "p98"
-                                        ],
-                                        "type": "field"
-                                    },
-                                    {
-                                        "params": [],
-                                        "type": "last"
-                                    },
-                                    {
-                                        "params": [
-                                            "98th Percentile"
-                                        ],
-                                        "type": "alias"
-                                    }
-                                ],
-                                [
-                                    {
-                                        "params": [
-                                            "p99"
-                                        ],
-                                        "type": "field"
-                                    },
-                                    {
-                                        "params": [],
-                                        "type": "last"
-                                    },
-                                    {
-                                        "params": [
-                                            "99th Percentile"
-                                        ],
-                                        "type": "alias"
-                                    }
-                                ]
-                            ],
-                            "step": 10,
-                            "tags": [
-                                {
-                                    "key": "env",
-                                    "operator": "=~",
-                                    "value": "/^$environment$/"
-                                },
-                                {
-                                    "condition": "AND",
-                                    "key": "app",
-                                    "operator": "=~",
-                                    "value": "/^$application$/"
-                                }
-                            ]
-                        },
-                        {
-                            "expr": "application_httprequests_transactions{env=\"$environment\",app=\"$application\",server=\"$server\",quantile=\"0.95\"}",
-                            "intervalFactor": 2,
-                            "legendFormat": "95th Percentile",
-                            "refId": "B",
-                            "step": 10
-                        },
-                        {
-                            "expr": "application_httprequests_transactions{env=\"$environment\",app=\"$application\",server=\"$server\",quantile=\"0.99\"}",
-                            "intervalFactor": 2,
-                            "legendFormat": "99th Percentile",
-                            "refId": "C",
-                            "step": 10
-                        }
-                    ],
-                    "thresholds": [],
-                    "timeFrom": null,
-                    "timeShift": null,
-                    "title": "Response Time",
-                    "tooltip": {
-                        "msResolution": false,
-                        "shared": true,
-                        "sort": 0,
-                        "value_type": "individual"
-                    },
-                    "type": "graph",
-                    "xaxis": {
-                        "mode": "time",
-                        "name": null,
-                        "show": true,
-                        "values": []
-                    },
-                    "yaxes": [
-                        {
-                            "format": "ms",
-                            "label": null,
-                            "logBase": 1,
-                            "max": null,
-                            "min": null,
-                            "show": true
-                        },
-                        {
-                            "format": "short",
-                            "label": null,
-                            "logBase": 1,
-                            "max": null,
-                            "min": null,
-                            "show": true
-                        }
-                    ]
-                },
-                {
-                    "aliasColors": {},
-                    "bars": false,
-                    "datasource": "$datasource",
-                    "editable": true,
-                    "error": false,
-                    "fill": 1,
-                    "height": "",
-                    "id": 9,
-                    "interval": "$summarize",
-                    "legend": {
-                        "alignAsTable": true,
-                        "avg": false,
-                        "current": true,
-                        "max": false,
-                        "min": false,
-                        "rightSide": true,
-                        "show": false,
-                        "total": false,
-                        "values": true
-                    },
-                    "lines": true,
-                    "linewidth": 1,
-                    "links": [],
-                    "nullPointMode": "connected",
-                    "percentage": false,
-                    "pointradius": 5,
-                    "points": false,
-                    "renderer": "flot",
-                    "seriesOverrides": [],
-                    "span": 4,
-                    "stack": false,
-                    "steppedLine": false,
-                    "targets": [
-                        {
-                            "alias": "",
-                            "dsType": "influxdb",
-                            "expr": "application_httprequests_one_minute_error_percentage_rate{env=\"$environment\",app=\"$application\",server=\"$server\"}",
-                            "groupBy": [
-                                {
-                                    "params": [
-                                        "$interval"
-                                    ],
-                                    "type": "time"
-                                },
-                                {
-                                    "params": [
-                                        "null"
-                                    ],
-                                    "type": "fill"
-                                }
-                            ],
-                            "intervalFactor": 2,
-                            "measurement": "application.httprequests__one_minute_error_percentage_rate",
-                            "policy": "default",
-                            "refId": "A",
-                            "resultFormat": "time_series",
-                            "select": [
-                                [
-                                    {
-                                        "params": [
-                                            "value"
-                                        ],
-                                        "type": "field"
-                                    },
-                                    {
-                                        "params": [],
-                                        "type": "last"
-                                    }
-                                ]
-                            ],
-                            "step": 10,
-                            "tags": [
-                                {
-                                    "key": "app",
-                                    "operator": "=~",
-                                    "value": "/^$application$/"
-                                },
-                                {
-                                    "condition": "AND",
-                                    "key": "env",
-                                    "operator": "=~",
-                                    "value": "/^$environment$/"
-                                }
-                            ]
-                        }
-                    ],
-                    "thresholds": [],
-                    "timeFrom": null,
-                    "timeShift": null,
-                    "title": "Error Rate %",
-                    "tooltip": {
-                        "msResolution": false,
-                        "shared": true,
-                        "sort": 0,
-                        "value_type": "individual"
-                    },
-                    "type": "graph",
-                    "xaxis": {
-                        "mode": "time",
-                        "name": null,
-                        "show": true,
-                        "values": []
-                    },
-                    "yaxes": [
-                        {
-                            "format": "percent",
-                            "label": null,
-                            "logBase": 1,
-                            "max": "100",
-                            "min": "0",
-                            "show": true
-                        },
-                        {
-                            "format": "short",
-                            "label": null,
-                            "logBase": 1,
-                            "max": null,
-                            "min": null,
-                            "show": true
-                        }
-                    ]
-                },
-                {
-                    "aliasColors": {},
-                    "cacheTimeout": null,
-                    "combine": {
-                        "label": "Others",
-                        "threshold": 0
-                    },
-                    "datasource": "$datasource",
-                    "editable": true,
-                    "error": false,
-                    "fontSize": "80%",
-                    "format": "percent",
-                    "height": "250px",
-                    "id": 4,
-                    "interval": "",
-                    "legend": {
-                        "percentage": true,
-                        "show": true,
-                        "sort": null,
-                        "sortDesc": null,
-                        "values": true
-                    },
-                    "legendType": "Right side",
-                    "links": [],
-                    "maxDataPoints": 3,
-                    "nullPointMode": "connected",
-                    "pieType": "pie",
-                    "span": 3,
-                    "strokeWidth": 1,
-                    "targets": [
-                        {
-                            "alias": "$tag_http_status_code",
-                            "dsType": "influxdb",
-                            "expr": "application_httprequests_errors{env=\"$environment\",app=\"$application\",server=\"$server\"}",
-                            "groupBy": [
-                                {
-                                    "params": [
-                                        "http_status_code"
-                                    ],
-                                    "type": "tag"
-                                }
-                            ],
-                            "intervalFactor": 2,
-                            "legendFormat": "{{http_status_code}}",
-                            "measurement": "application.httprequests__errors",
-                            "policy": "default",
-                            "refId": "A",
-                            "resultFormat": "time_series",
-                            "select": [
-                                [
-                                    {
-                                        "params": [
-                                            "value"
-                                        ],
-                                        "type": "field"
-                                    },
-                                    {
-                                        "params": [],
-                                        "type": "sum"
-                                    }
-                                ]
-                            ],
-                            "step": 240,
-                            "tags": [
-                                {
-                                    "key": "app",
-                                    "operator": "=~",
-                                    "value": "/^$application$/"
-                                },
-                                {
-                                    "condition": "AND",
-                                    "key": "env",
-                                    "operator": "=~",
-                                    "value": "/^$environment$/"
-                                }
-                            ]
-                        }
-                    ],
-                    "title": "Errors",
-                    "type": "grafana-piechart-panel",
-                    "valueName": "current"
-                },
-                {
-                    "aliasColors": {},
-                    "bars": false,
-                    "datasource": "$datasource",
-                    "decimals": 2,
-                    "editable": true,
-                    "error": false,
-                    "fill": 1,
-                    "height": "250px",
-                    "id": 3,
-                    "interval": "$summarize",
-                    "legend": {
-                        "alignAsTable": true,
-                        "avg": false,
-                        "current": true,
-                        "max": false,
-                        "min": false,
-                        "rightSide": true,
-                        "show": true,
-                        "total": false,
-                        "values": true
-                    },
-                    "lines": true,
-                    "linewidth": 1,
-                    "links": [],
-                    "nullPointMode": "connected",
-                    "percentage": false,
-                    "pointradius": 5,
-                    "points": false,
-                    "renderer": "flot",
-                    "seriesOverrides": [],
-                    "span": 5,
-                    "stack": false,
-                    "steppedLine": false,
-                    "targets": [
-                        {
-                            "alias": "$col",
-                            "dsType": "influxdb",
-                            "expr": "rate(application_httprequests_error_rate_total[1m])*60",
-                            "groupBy": [
-                                {
-                                    "params": [
-                                        "$interval"
-                                    ],
-                                    "type": "time"
-                                },
-                                {
-                                    "params": [
-                                        "null"
-                                    ],
-                                    "type": "fill"
-                                }
-                            ],
-                            "intervalFactor": 2,
-                            "legendFormat": "1min rate",
-                            "measurement": "application.httprequests__error_rate",
-                            "policy": "default",
-                            "refId": "A",
-                            "resultFormat": "time_series",
-                            "select": [
-                                [
-                                    {
-                                        "params": [
-                                            "rate1m"
-                                        ],
-                                        "type": "field"
-                                    },
-                                    {
-                                        "params": [],
-                                        "type": "last"
-                                    },
-                                    {
-                                        "params": [
-                                            "1min rate"
-                                        ],
-                                        "type": "alias"
-                                    }
-                                ],
-                                [
-                                    {
-                                        "params": [
-                                            "rate5m"
-                                        ],
-                                        "type": "field"
-                                    },
-                                    {
-                                        "params": [],
-                                        "type": "last"
-                                    },
-                                    {
-                                        "params": [
-                                            "5min rate"
-                                        ],
-                                        "type": "alias"
-                                    }
-                                ],
-                                [
-                                    {
-                                        "params": [
-                                            "rate15m"
-                                        ],
-                                        "type": "field"
-                                    },
-                                    {
-                                        "params": [],
-                                        "type": "last"
-                                    },
-                                    {
-                                        "params": [
-                                            "15min rate"
-                                        ],
-                                        "type": "alias"
-                                    }
-                                ]
-                            ],
-                            "step": 10,
-                            "tags": [
-                                {
-                                    "key": "app",
-                                    "operator": "=~",
-                                    "value": "/^$application$/"
-                                },
-                                {
-                                    "condition": "AND",
-                                    "key": "env",
-                                    "operator": "=~",
-                                    "value": "/^$environment$/"
-                                }
-                            ]
-                        },
-                        {
-                            "expr": "rate(application_httprequests_error_rate_total[5m])*60",
-                            "intervalFactor": 2,
-                            "legendFormat": "5min rate",
-                            "refId": "B",
-                            "step": 10
-                        },
-                        {
-                            "expr": "rate(application_httprequests_error_rate_total[15m])*60",
-                            "intervalFactor": 2,
-                            "legendFormat": "15min rate",
-                            "refId": "C",
-                            "step": 10
-                        }
-                    ],
-                    "thresholds": [],
-                    "timeFrom": null,
-                    "timeShift": null,
-                    "title": "Error Rate",
-                    "tooltip": {
-                        "msResolution": false,
-                        "shared": true,
-                        "sort": 2,
-                        "value_type": "individual"
-                    },
-                    "type": "graph",
-                    "xaxis": {
-                        "mode": "time",
-                        "name": null,
-                        "show": true,
-                        "values": []
-                    },
-                    "yaxes": [
-                        {
-                            "format": "rpm",
-                            "label": null,
-                            "logBase": 1,
-                            "max": null,
-                            "min": null,
-                            "show": true
-                        },
-                        {
-                            "format": "short",
-                            "label": null,
-                            "logBase": 1,
-                            "max": null,
-                            "min": null,
-                            "show": true
-                        }
-                    ]
-                }
-            ],
-            "repeat": null,
-            "repeatIteration": null,
-            "repeatRowId": null,
-            "showTitle": true,
-            "title": "Overview",
-            "titleSize": "h6"
-        },
-        {
-            "collapse": false,
-            "height": "300",
-            "panels": [
-                {
-                    "aliasColors": {},
-                    "bars": false,
-                    "datasource": "$datasource",
-                    "editable": true,
-                    "error": false,
-                    "fill": 1,
-                    "height": "350",
-                    "id": 16,
-                    "interval": "$summarize",
-                    "legend": {
-                        "alignAsTable": true,
-                        "avg": false,
-                        "current": false,
-                        "max": false,
-                        "min": false,
-                        "rightSide": true,
-                        "show": true,
-                        "sort": "current",
-                        "sortDesc": true,
-                        "total": false,
-                        "values": false
-                    },
-                    "lines": true,
-                    "linewidth": 1,
-                    "links": [],
-                    "nullPointMode": "connected",
-                    "percentage": false,
-                    "pointradius": 5,
-                    "points": false,
-                    "renderer": "flot",
-                    "seriesOverrides": [],
-                    "span": 6,
-                    "stack": true,
-                    "steppedLine": false,
-                    "targets": [
-                        {
-                            "alias": "$tag_route",
-                            "dsType": "influxdb",
-                            "expr": "rate(application_httprequests_transactions_per_endpoint_count{env=\"$environment\",app=\"$application\",server=\"$server\"}[1m])*60",
-                            "groupBy": [
-                                {
-                                    "params": [
-                                        "$interval"
-                                    ],
-                                    "type": "time"
-                                },
-                                {
-                                    "params": [
-                                        "route"
-                                    ],
-                                    "type": "tag"
-                                },
-                                {
-                                    "params": [
-                                        "null"
-                                    ],
-                                    "type": "fill"
-                                }
-                            ],
-                            "intervalFactor": 2,
-                            "legendFormat": "{{route}}",
-                            "measurement": "application.httprequests__transactions_per_endpoint",
-                            "policy": "default",
-                            "refId": "A",
-                            "resultFormat": "time_series",
-                            "select": [
-                                [
-                                    {
-                                        "params": [
-                                            "rate1m"
-                                        ],
-                                        "type": "field"
-                                    },
-                                    {
-                                        "params": [],
-                                        "type": "last"
-                                    }
-                                ]
-                            ],
-                            "step": 10,
-                            "tags": [
-                                {
-                                    "key": "env",
-                                    "operator": "=~",
-                                    "value": "/^$environment$/"
-                                },
-                                {
-                                    "condition": "AND",
-                                    "key": "app",
-                                    "operator": "=~",
-                                    "value": "/^$application$/"
-                                }
-                            ]
-                        }
-                    ],
-                    "thresholds": [],
-                    "timeFrom": null,
-                    "timeShift": null,
-                    "title": "Throughput / Endpoint",
-                    "tooltip": {
-                        "msResolution": false,
-                        "shared": true,
-                        "sort": 2,
-                        "value_type": "individual"
-                    },
-                    "transparent": false,
-                    "type": "graph",
-                    "xaxis": {
-                        "mode": "time",
-                        "name": null,
-                        "show": true,
-                        "values": []
-                    },
-                    "yaxes": [
-                        {
-                            "format": "rpm",
-                            "label": null,
-                            "logBase": 1,
-                            "max": null,
-                            "min": null,
-                            "show": true
-                        },
-                        {
-                            "format": "short",
-                            "label": null,
-                            "logBase": 1,
-                            "max": null,
-                            "min": null,
-                            "show": true
-                        }
-                    ]
-                },
-                {
-                    "aliasColors": {},
-                    "bars": false,
-                    "datasource": "$datasource",
-                    "editable": true,
-                    "error": false,
-                    "fill": 1,
-                    "height": "350",
-                    "id": 17,
-                    "interval": "$summarize",
-                    "legend": {
-                        "alignAsTable": true,
-                        "avg": false,
-                        "current": false,
-                        "max": false,
-                        "min": false,
-                        "rightSide": true,
-                        "show": true,
-                        "total": false,
-                        "values": false
-                    },
-                    "lines": true,
-                    "linewidth": 1,
-                    "links": [],
-                    "nullPointMode": "connected",
-                    "percentage": false,
-                    "pointradius": 5,
-                    "points": false,
-                    "renderer": "flot",
-                    "seriesOverrides": [],
-                    "span": 6,
-                    "stack": false,
-                    "steppedLine": false,
-                    "targets": [
-                        {
-                            "alias": "$tag_route",
-                            "dsType": "influxdb",
-                            "expr": "application_httprequests_transactions_per_endpoint{env=\"$environment\",app=\"$application\",server=\"$server\",quantile=\"0.95\"}",
-                            "groupBy": [
-                                {
-                                    "params": [
-                                        "$interval"
-                                    ],
-                                    "type": "time"
-                                },
-                                {
-                                    "params": [
-                                        "route"
-                                    ],
-                                    "type": "tag"
-                                },
-                                {
-                                    "params": [
-                                        "null"
-                                    ],
-                                    "type": "fill"
-                                }
-                            ],
-                            "intervalFactor": 2,
-                            "legendFormat": "{{route}}",
-                            "measurement": "application.httprequests__transactions_per_endpoint",
-                            "policy": "default",
-                            "refId": "A",
-                            "resultFormat": "time_series",
-                            "select": [
-                                [
-                                    {
-                                        "params": [
-                                            "p95"
-                                        ],
-                                        "type": "field"
-                                    },
-                                    {
-                                        "params": [],
-                                        "type": "last"
-                                    },
-                                    {
-                                        "params": [
-                                            "95th Percentile"
-                                        ],
-                                        "type": "alias"
-                                    }
-                                ]
-                            ],
-                            "step": 10,
-                            "tags": [
-                                {
-                                    "key": "env",
-                                    "operator": "=~",
-                                    "value": "/^$environment$/"
-                                },
-                                {
-                                    "condition": "AND",
-                                    "key": "app",
-                                    "operator": "=~",
-                                    "value": "/^$application$/"
-                                }
-                            ]
-                        }
-                    ],
-                    "thresholds": [],
-                    "timeFrom": null,
-                    "timeShift": null,
-                    "title": "Response Time / Endpoint",
-                    "tooltip": {
-                        "msResolution": false,
-                        "shared": true,
-                        "sort": 0,
-                        "value_type": "individual"
-                    },
-                    "type": "graph",
-                    "xaxis": {
-                        "mode": "time",
-                        "name": null,
-                        "show": true,
-                        "values": []
-                    },
-                    "yaxes": [
-                        {
-                            "format": "ms",
-                            "label": null,
-                            "logBase": 1,
-                            "max": null,
-                            "min": null,
-                            "show": true
-                        },
-                        {
-                            "format": "short",
-                            "label": null,
-                            "logBase": 1,
-                            "max": null,
-                            "min": null,
-                            "show": true
-                        }
-                    ]
-                },
-                {
-                    "columns": [
-                        {
-                            "text": "Current",
-                            "value": "current"
-                        }
-                    ],
-                    "datasource": "$datasource",
-                    "editable": true,
-                    "error": false,
-                    "filterNull": false,
-                    "fontSize": "100%",
-                    "id": 10,
-                    "interval": "",
-                    "links": [],
-                    "pageSize": null,
-                    "scroll": true,
-                    "showHeader": true,
-                    "sort": {
-                        "col": 1,
-                        "desc": true
-                    },
-                    "span": 4,
-                    "styles": [
-                        {
-                            "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                            "pattern": "Time",
-                            "type": "date"
-                        },
-                        {
-                            "colorMode": null,
-                            "colors": [
-                                "rgba(245, 54, 54, 0.9)",
-                                "rgba(237, 129, 40, 0.89)",
-                                "rgba(50, 172, 45, 0.97)"
-                            ],
-                            "decimals": 2,
-                            "pattern": "/.*/",
-                            "thresholds": [],
-                            "type": "number",
-                            "unit": "ms"
-                        }
-                    ],
-                    "targets": [
-                        {
-                            "alias": "$tag_route",
-                            "dsType": "influxdb",
-                            "expr": "application_httprequests_transactions_per_endpoint{env=\"$environment\",app=\"$application\",server=\"$server\",quantile=\"0.95\"}",
-                            "groupBy": [
-                                {
-                                    "params": [
-                                        "$interval"
-                                    ],
-                                    "type": "time"
-                                },
-                                {
-                                    "params": [
-                                        "route"
-                                    ],
-                                    "type": "tag"
-                                },
-                                {
-                                    "params": [
-                                        "null"
-                                    ],
-                                    "type": "fill"
-                                }
-                            ],
-                            "intervalFactor": 2,
-                            "legendFormat": "{{route}}",
-                            "measurement": "application.httprequests__transactions_per_endpoint",
-                            "policy": "default",
-                            "refId": "A",
-                            "resultFormat": "time_series",
-                            "select": [
-                                [
-                                    {
-                                        "params": [
-                                            "p95"
-                                        ],
-                                        "type": "field"
-                                    },
-                                    {
-                                        "params": [],
-                                        "type": "last"
-                                    }
-                                ]
-                            ],
-                            "step": 2,
-                            "tags": [
-                                {
-                                    "key": "env",
-                                    "operator": "=~",
-                                    "value": "/^$environment$/"
-                                },
-                                {
-                                    "condition": "AND",
-                                    "key": "app",
-                                    "operator": "=~",
-                                    "value": "/^$application$/"
-                                }
-                            ]
-                        }
-                    ],
-                    "title": "Response Times / Endpoint",
-                    "transform": "timeseries_aggregations",
-                    "type": "table"
-                },
-                {
-                    "columns": [
-                        {
-                            "text": "Current",
-                            "value": "current"
-                        }
-                    ],
-                    "datasource": "$datasource",
-                    "editable": true,
-                    "error": false,
-                    "filterNull": false,
-                    "fontSize": "100%",
-                    "id": 11,
-                    "interval": "",
-                    "links": [],
-                    "pageSize": null,
-                    "scroll": true,
-                    "showHeader": true,
-                    "sort": {
-                        "col": null,
-                        "desc": false
-                    },
-                    "span": 4,
-                    "styles": [
-                        {
-                            "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                            "pattern": "Time",
-                            "type": "date"
-                        },
-                        {
-                            "colorMode": null,
-                            "colors": [
-                                "rgba(245, 54, 54, 0.9)",
-                                "rgba(237, 129, 40, 0.89)",
-                                "rgba(50, 172, 45, 0.97)"
-                            ],
-                            "decimals": 0,
-                            "pattern": "/.*/",
-                            "thresholds": [],
-                            "type": "number",
-                            "unit": "percent"
-                        }
-                    ],
-                    "targets": [
-                        {
-                            "alias": "$tag_route",
-                            "dsType": "influxdb",
-                            "expr": "application_httprequests_one_minute_error_percentage_rate_per_endpoint{env=\"$environment\",app=\"$application\",server=\"$server\"}",
-                            "groupBy": [
-                                {
-                                    "params": [
-                                        "$interval"
-                                    ],
-                                    "type": "time"
-                                },
-                                {
-                                    "params": [
-                                        "route"
-                                    ],
-                                    "type": "tag"
-                                },
-                                {
-                                    "params": [
-                                        "null"
-                                    ],
-                                    "type": "fill"
-                                }
-                            ],
-                            "intervalFactor": 2,
-                            "legendFormat": "{{route}}",
-                            "measurement": "application.httprequests__one_minute_error_percentage_rate_per_endpoint",
-                            "policy": "default",
-                            "refId": "A",
-                            "resultFormat": "time_series",
-                            "select": [
-                                [
-                                    {
-                                        "params": [
-                                            "value"
-                                        ],
-                                        "type": "field"
-                                    },
-                                    {
-                                        "params": [],
-                                        "type": "last"
-                                    }
-                                ]
-                            ],
-                            "step": 2,
-                            "tags": [
-                                {
-                                    "key": "app",
-                                    "operator": "=~",
-                                    "value": "/^$application$/"
-                                },
-                                {
-                                    "condition": "AND",
-                                    "key": "env",
-                                    "operator": "=~",
-                                    "value": "/^$environment$/"
-                                }
-                            ]
-                        }
-                    ],
-                    "title": "Error Request Percentage / Endpoint",
-                    "transform": "timeseries_aggregations",
-                    "type": "table"
-                },
-                {
-                    "columns": [
-                        {
-                            "text": "Current",
-                            "value": "current"
-                        }
-                    ],
-                    "datasource": "$datasource",
-                    "editable": true,
-                    "error": false,
-                    "filterNull": false,
-                    "fontSize": "100%",
-                    "id": 12,
-                    "interval": "",
-                    "links": [],
-                    "pageSize": null,
-                    "scroll": true,
-                    "showHeader": true,
-                    "sort": {
-                        "col": 1,
-                        "desc": true
-                    },
-                    "span": 4,
-                    "styles": [
-                        {
-                            "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                            "pattern": "Time",
-                            "type": "date"
-                        },
-                        {
-                            "colorMode": null,
-                            "colors": [
-                                "rgba(245, 54, 54, 0.9)",
-                                "rgba(237, 129, 40, 0.89)",
-                                "rgba(50, 172, 45, 0.97)"
-                            ],
-                            "decimals": 2,
-                            "pattern": "/.*/",
-                            "thresholds": [],
-                            "type": "number",
-                            "unit": "rpm"
-                        }
-                    ],
-                    "targets": [
-                        {
-                            "alias": "$tag_route",
-                            "dsType": "influxdb",
-                            "expr": "rate(application_httprequests_transactions_per_endpoint_count{env=\"$environment\",app=\"$application\",server=\"$server\"}[1m])*60",
-                            "groupBy": [
-                                {
-                                    "params": [
-                                        "$interval"
-                                    ],
-                                    "type": "time"
-                                },
-                                {
-                                    "params": [
-                                        "route"
-                                    ],
-                                    "type": "tag"
-                                },
-                                {
-                                    "params": [
-                                        "null"
-                                    ],
-                                    "type": "fill"
-                                }
-                            ],
-                            "intervalFactor": 2,
-                            "legendFormat": "{{route}}",
-                            "measurement": "application.httprequests__transactions_per_endpoint",
-                            "policy": "default",
-                            "refId": "A",
-                            "resultFormat": "time_series",
-                            "select": [
-                                [
-                                    {
-                                        "params": [
-                                            "rate1m"
-                                        ],
-                                        "type": "field"
-                                    },
-                                    {
-                                        "params": [],
-                                        "type": "last"
-                                    }
-                                ]
-                            ],
-                            "step": 2,
-                            "tags": [
-                                {
-                                    "key": "env",
-                                    "operator": "=~",
-                                    "value": "/^$environment$/"
-                                },
-                                {
-                                    "condition": "AND",
-                                    "key": "app",
-                                    "operator": "=~",
-                                    "value": "/^$application$/"
-                                }
-                            ]
-                        }
-                    ],
-                    "title": "Throughput / Endpoint",
-                    "transform": "timeseries_aggregations",
-                    "type": "table"
-                }
-            ],
-            "repeat": null,
-            "repeatIteration": null,
-            "repeatRowId": null,
-            "showTitle": true,
-            "title": "Endpoints",
-            "titleSize": "h6"
-        },
-        {
-            "collapse": false,
-            "height": "250",
-            "panels": [
-                {
-                    "columns": [
-                        {
-                            "text": "Current",
-                            "value": "current"
-                        }
-                    ],
-                    "datasource": "$datasource",
-                    "editable": true,
-                    "error": false,
-                    "filterNull": false,
-                    "fontSize": "100%",
-                    "hideTimeOverride": true,
-                    "id": 22,
-                    "interval": "",
-                    "links": [],
-                    "pageSize": null,
-                    "scroll": true,
-                    "showHeader": true,
-                    "sort": {
-                        "col": 0,
-                        "desc": true
-                    },
-                    "span": 9,
-                    "styles": [
-                        {
-                            "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                            "pattern": "Time",
-                            "type": "date"
-                        },
-                        {
-                            "colorMode": "row",
-                            "colors": [
-                                "rgba(245, 54, 54, 0.9)",
-                                "rgba(237, 129, 40, 0.89)",
-                                "rgba(50, 172, 45, 0.97)"
-                            ],
-                            "decimals": 1,
-                            "pattern": "/.*/",
-                            "thresholds": [
-                                "0.5",
-                                "1"
-                            ],
-                            "type": "number",
-                            "unit": "short"
-                        }
-                    ],
-                    "targets": [
-                        {
-                            "alias": "$tag_health_check_name",
-                            "dsType": "influxdb",
-                            "expr": "application_health_results{env=\"stage\",app=\"$application\",server=\"$server\"}",
-                            "groupBy": [
-                                {
-                                    "params": [
-                                        "$interval"
-                                    ],
-                                    "type": "time"
-                                },
-                                {
-                                    "params": [
-                                        "health_check_name"
-                                    ],
-                                    "type": "tag"
-                                },
-                                {
-                                    "params": [
-                                        "null"
-                                    ],
-                                    "type": "fill"
-                                }
-                            ],
-                            "intervalFactor": 2,
-                            "legendFormat": "{{health_check_name}}",
-                            "measurement": "application.health__results",
-                            "metric": "application_health_results",
-                            "policy": "default",
-                            "refId": "A",
-                            "resultFormat": "time_series",
-                            "select": [
-                                [
-                                    {
-                                        "params": [
-                                            "value"
-                                        ],
-                                        "type": "field"
-                                    },
-                                    {
-                                        "params": [],
-                                        "type": "last"
-                                    }
-                                ]
-                            ],
-                            "step": 2,
-                            "tags": [
-                                {
-                                    "key": "env",
-                                    "operator": "=~",
-                                    "value": "/^$environment$/"
-                                },
-                                {
-                                    "condition": "AND",
-                                    "key": "app",
-                                    "operator": "=~",
-                                    "value": "/^$application$/"
-                                }
-                            ]
-                        }
-                    ],
-                    "timeFrom": null,
-                    "title": "Results",
-                    "transform": "timeseries_aggregations",
-                    "transparent": true,
-                    "type": "table"
-                },
-                {
-                    "cacheTimeout": null,
-                    "colorBackground": true,
-                    "colorValue": false,
-                    "colors": [
-                        "rgba(245, 54, 54, 0.9)",
-                        "rgba(237, 129, 40, 0.89)",
-                        "rgba(50, 172, 45, 0.97)"
-                    ],
-                    "datasource": "$datasource",
-                    "editable": true,
-                    "error": false,
-                    "format": "none",
-                    "gauge": {
-                        "maxValue": 100,
-                        "minValue": 0,
-                        "show": false,
-                        "thresholdLabels": false,
-                        "thresholdMarkers": true
-                    },
-                    "hideTimeOverride": true,
-                    "id": 19,
-                    "interval": null,
-                    "links": [
-                        {
-                            "type": "dashboard"
-                        }
-                    ],
-                    "mappingType": 2,
-                    "mappingTypes": [
-                        {
-                            "name": "value to text",
-                            "value": 1
-                        },
-                        {
-                            "name": "range to text",
-                            "value": 2
-                        }
-                    ],
-                    "maxDataPoints": 100,
-                    "nullPointMode": "connected",
-                    "nullText": null,
-                    "postfix": "",
-                    "postfixFontSize": "50%",
-                    "prefix": "",
-                    "prefixFontSize": "50%",
-                    "rangeMaps": [
-                        {
-                            "from": "0",
-                            "text": "Unhealthy",
-                            "to": "0.49"
-                        },
-                        {
-                            "from": "0.5",
-                            "text": "Degraded",
-                            "to": "0.9"
-                        },
-                        {
-                            "from": "1.0",
-                            "text": "Healthy",
-                            "to": "2.0"
-                        }
-                    ],
-                    "span": 3,
-                    "sparkline": {
-                        "fillColor": "rgba(31, 118, 189, 0.18)",
-                        "full": false,
-                        "lineColor": "rgb(31, 120, 193)",
-                        "show": false
-                    },
-                    "targets": [
-                        {
-                            "dsType": "influxdb",
-                            "expr": "application_health_score{env=\"stage\",app=\"$application\",server=\"$server\"}",
-                            "groupBy": [
-                                {
-                                    "params": [
-                                        "$interval"
-                                    ],
-                                    "type": "time"
-                                },
-                                {
-                                    "params": [
-                                        "null"
-                                    ],
-                                    "type": "fill"
-                                }
-                            ],
-                            "intervalFactor": 2,
-                            "measurement": "application.health__score",
-                            "metric": "application_health_score",
-                            "policy": "default",
-                            "refId": "A",
-                            "resultFormat": "time_series",
-                            "select": [
-                                [
-                                    {
-                                        "params": [
-                                            "value"
-                                        ],
-                                        "type": "field"
-                                    },
-                                    {
-                                        "params": [],
-                                        "type": "last"
-                                    }
-                                ]
-                            ],
-                            "step": 4,
-                            "tags": [
-                                {
-                                    "key": "env",
-                                    "operator": "=~",
-                                    "value": "/^$environment$/"
-                                },
-                                {
-                                    "condition": "AND",
-                                    "key": "app",
-                                    "operator": "=~",
-                                    "value": "/^$application$/"
-                                }
-                            ]
-                        }
-                    ],
-                    "thresholds": "0.5,1",
-                    "timeFrom": null,
-                    "title": "",
-                    "transparent": true,
-                    "type": "singlestat",
-                    "valueFontSize": "80%",
-                    "valueMaps": [
-                        {
-                            "op": "=",
-                            "text": "Unhealthy",
-                            "value": "0"
-                        },
-                        {
-                            "op": "=",
-                            "text": "Degraded",
-                            "value": "0.5"
-                        },
-                        {
-                            "op": "=",
-                            "text": "Healthy",
-                            "value": "1.0"
-                        }
-                    ],
-                    "valueName": "current"
-                }
-            ],
-            "repeat": null,
-            "repeatIteration": null,
-            "repeatRowId": null,
-            "showTitle": true,
-            "title": "Health",
-            "titleSize": "h6"
-        },
-        {
-            "collapse": false,
-            "height": "300",
-            "panels": [
-                {
-                    "aliasColors": {},
-                    "bars": false,
-                    "datasource": "$datasource",
-                    "editable": true,
-                    "error": false,
-                    "fill": 1,
-                    "id": 14,
-                    "interval": "$summarize",
-                    "legend": {
-                        "alignAsTable": true,
-                        "avg": false,
-                        "current": true,
-                        "hideEmpty": false,
-                        "max": false,
-                        "min": false,
-                        "rightSide": true,
-                        "show": true,
-                        "total": false,
-                        "values": true
-                    },
-                    "lines": true,
-                    "linewidth": 1,
-                    "links": [],
-                    "nullPointMode": "connected",
-                    "percentage": false,
-                    "pointradius": 5,
-                    "points": false,
-                    "renderer": "flot",
-                    "seriesOverrides": [],
-                    "span": 6,
-                    "stack": false,
-                    "steppedLine": false,
-                    "targets": [
-                        {
-                            "alias": "$col",
-                            "dsType": "influxdb",
-                            "expr": "application_httprequests_post_size{env=\"$environment\",app=\"$application\",server=\"$server\",quantile=\"0.75\"}",
-                            "groupBy": [
-                                {
-                                    "params": [
-                                        "$interval"
-                                    ],
-                                    "type": "time"
-                                },
-                                {
-                                    "params": [
-                                        "null"
-                                    ],
-                                    "type": "fill"
-                                }
-                            ],
-                            "intervalFactor": 2,
-                            "legendFormat": "75th Percentile",
-                            "measurement": "application.httprequests__post_size",
-                            "policy": "default",
-                            "refId": "A",
-                            "resultFormat": "time_series",
-                            "select": [
-                                [
-                                    {
-                                        "params": [
-                                            "p95"
-                                        ],
-                                        "type": "field"
-                                    },
-                                    {
-                                        "params": [],
-                                        "type": "last"
-                                    },
-                                    {
-                                        "params": [
-                                            "95th percentile"
-                                        ],
-                                        "type": "alias"
-                                    }
-                                ],
-                                [
-                                    {
-                                        "params": [
-                                            "p98"
-                                        ],
-                                        "type": "field"
-                                    },
-                                    {
-                                        "params": [],
-                                        "type": "last"
-                                    },
-                                    {
-                                        "params": [
-                                            "98th percentile"
-                                        ],
-                                        "type": "alias"
-                                    }
-                                ],
-                                [
-                                    {
-                                        "params": [
-                                            "p99"
-                                        ],
-                                        "type": "field"
-                                    },
-                                    {
-                                        "params": [],
-                                        "type": "last"
-                                    },
-                                    {
-                                        "params": [
-                                            "99th percentile"
-                                        ],
-                                        "type": "alias"
-                                    }
-                                ],
-                                [
-                                    {
-                                        "params": [
-                                            "last"
-                                        ],
-                                        "type": "field"
-                                    },
-                                    {
-                                        "params": [],
-                                        "type": "median"
-                                    },
-                                    {
-                                        "params": [
-                                            "median"
-                                        ],
-                                        "type": "alias"
-                                    }
-                                ]
-                            ],
-                            "step": 10,
-                            "tags": [
-                                {
-                                    "key": "app",
-                                    "operator": "=~",
-                                    "value": "/^$application$/"
-                                },
-                                {
-                                    "condition": "AND",
-                                    "key": "env",
-                                    "operator": "=~",
-                                    "value": "/^$environment$/"
-                                }
-                            ]
-                        },
-                        {
-                            "expr": "application_httprequests_post_size{env=\"$environment\",app=\"$application\",server=\"$server\",quantile=\"0.95\"}",
-                            "intervalFactor": 2,
-                            "legendFormat": "95th Percentile",
-                            "refId": "B",
-                            "step": 10
-                        },
-                        {
-                            "expr": "application_httprequests_post_size{env=\"$environment\",app=\"$application\",server=\"$server\",quantile=\"0.99\"}",
-                            "intervalFactor": 2,
-                            "legendFormat": "99th Percentile",
-                            "refId": "C",
-                            "step": 10
-                        }
-                    ],
-                    "thresholds": [],
-                    "timeFrom": null,
-                    "timeShift": null,
-                    "title": "Post Request Size",
-                    "tooltip": {
-                        "msResolution": false,
-                        "shared": true,
-                        "sort": 0,
-                        "value_type": "individual"
-                    },
-                    "type": "graph",
-                    "xaxis": {
-                        "mode": "time",
-                        "name": null,
-                        "show": true,
-                        "values": []
-                    },
-                    "yaxes": [
-                        {
-                            "format": "decbytes",
-                            "label": null,
-                            "logBase": 1,
-                            "max": null,
-                            "min": null,
-                            "show": true
-                        },
-                        {
-                            "format": "short",
-                            "label": null,
-                            "logBase": 1,
-                            "max": null,
-                            "min": null,
-                            "show": true
-                        }
-                    ]
-                },
-                {
-                    "aliasColors": {},
-                    "bars": false,
-                    "datasource": "$datasource",
-                    "editable": true,
-                    "error": false,
-                    "fill": 1,
-                    "id": 15,
-                    "interval": "$summarize",
-                    "legend": {
-                        "alignAsTable": true,
-                        "avg": false,
-                        "current": true,
-                        "max": false,
-                        "min": false,
-                        "rightSide": true,
-                        "show": true,
-                        "total": false,
-                        "values": true
-                    },
-                    "lines": true,
-                    "linewidth": 1,
-                    "links": [],
-                    "nullPointMode": "connected",
-                    "percentage": false,
-                    "pointradius": 5,
-                    "points": false,
-                    "renderer": "flot",
-                    "seriesOverrides": [],
-                    "span": 6,
-                    "stack": false,
-                    "steppedLine": false,
-                    "targets": [
-                        {
-                            "alias": "$col",
-                            "dsType": "influxdb",
-                            "expr": "application_httprequests_put_size{env=\"$environment\",app=\"$application\",server=\"$server\",quantile=\"0.75\"}",
-                            "groupBy": [
-                                {
-                                    "params": [
-                                        "$interval"
-                                    ],
-                                    "type": "time"
-                                },
-                                {
-                                    "params": [
-                                        "null"
-                                    ],
-                                    "type": "fill"
-                                }
-                            ],
-                            "intervalFactor": 2,
-                            "legendFormat": "75th Percentile",
-                            "measurement": "application.httprequests__put_size",
-                            "policy": "default",
-                            "refId": "A",
-                            "resultFormat": "time_series",
-                            "select": [
-                                [
-                                    {
-                                        "params": [
-                                            "p95"
-                                        ],
-                                        "type": "field"
-                                    },
-                                    {
-                                        "params": [],
-                                        "type": "last"
-                                    },
-                                    {
-                                        "params": [
-                                            "95th percentile"
-                                        ],
-                                        "type": "alias"
-                                    }
-                                ],
-                                [
-                                    {
-                                        "params": [
-                                            "p98"
-                                        ],
-                                        "type": "field"
-                                    },
-                                    {
-                                        "params": [],
-                                        "type": "last"
-                                    },
-                                    {
-                                        "params": [
-                                            "98th percentile"
-                                        ],
-                                        "type": "alias"
-                                    }
-                                ],
-                                [
-                                    {
-                                        "params": [
-                                            "p99"
-                                        ],
-                                        "type": "field"
-                                    },
-                                    {
-                                        "params": [],
-                                        "type": "last"
-                                    },
-                                    {
-                                        "params": [
-                                            "99th percentile"
-                                        ],
-                                        "type": "alias"
-                                    }
-                                ],
-                                [
-                                    {
-                                        "params": [
-                                            "median"
-                                        ],
-                                        "type": "field"
-                                    },
-                                    {
-                                        "params": [],
-                                        "type": "median"
-                                    },
-                                    {
-                                        "params": [
-                                            "median"
-                                        ],
-                                        "type": "alias"
-                                    }
-                                ]
-                            ],
-                            "step": 10,
-                            "tags": [
-                                {
-                                    "key": "app",
-                                    "operator": "=~",
-                                    "value": "/^$application$/"
-                                },
-                                {
-                                    "condition": "AND",
-                                    "key": "env",
-                                    "operator": "=~",
-                                    "value": "/^$environment$/"
-                                }
-                            ]
-                        },
-                        {
-                            "expr": "application_httprequests_put_size{env=\"$environment\",app=\"$application\",server=\"$server\",quantile=\"0.95\"}",
-                            "intervalFactor": 2,
-                            "legendFormat": "95th Percentile",
-                            "refId": "B",
-                            "step": 10
-                        },
-                        {
-                            "expr": "application_httprequests_put_size{env=\"$environment\",app=\"$application\",server=\"$server\",quantile=\"0.99\"}",
-                            "intervalFactor": 2,
-                            "legendFormat": "99th Percentile",
-                            "refId": "C",
-                            "step": 10
-                        }
-                    ],
-                    "thresholds": [],
-                    "timeFrom": null,
-                    "timeShift": null,
-                    "title": "Put Request Size",
-                    "tooltip": {
-                        "msResolution": false,
-                        "shared": true,
-                        "sort": 0,
-                        "value_type": "individual"
-                    },
-                    "type": "graph",
-                    "xaxis": {
-                        "mode": "time",
-                        "name": null,
-                        "show": true,
-                        "values": []
-                    },
-                    "yaxes": [
-                        {
-                            "format": "bytes",
-                            "label": null,
-                            "logBase": 1,
-                            "max": null,
-                            "min": null,
-                            "show": true
-                        },
-                        {
-                            "format": "short",
-                            "label": null,
-                            "logBase": 1,
-                            "max": null,
-                            "min": null,
-                            "show": true
-                        }
-                    ]
-                }
-            ],
-            "repeat": null,
-            "repeatIteration": null,
-            "repeatRowId": null,
-            "showTitle": true,
-            "title": "PUT & POST Request Size",
-            "titleSize": "h6"
-        }
-    ],
-    "schemaVersion": 14,
-    "style": "dark",
-    "tags": [
-        "prometheus"
-    ],
-    "templating": {
-        "list": [
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "datasource": "$datasource",
+          "editable": true,
+          "error": false,
+          "format": "rpm",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 8,
+          "interval": "",
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
             {
-                "allValue": null,
-                "current": {
-                    "text": "stage",
-                    "value": "stage"
-                },
-                "datasource": "$datasource",
-                "hide": 0,
-                "includeAll": false,
-                "label": null,
-                "multi": false,
-                "name": "environment",
-                "options": [],
-                "query": "label_values(env)",
-                "refresh": 1,
-                "regex": "",
-                "sort": 1,
-                "tagValuesQuery": null,
-                "tags": [],
-                "tagsQuery": null,
-                "type": "query",
-                "useTags": false
+              "name": "value to text",
+              "value": 1
             },
             {
-                "allValue": null,
-                "current": {
-                    "text": "App.Metrics.Prometheus.Sandbox",
-                    "value": "App.Metrics.Prometheus.Sandbox"
-                },
-                "datasource": "$datasource",
-                "hide": 0,
-                "includeAll": false,
-                "label": null,
-                "multi": false,
-                "name": "application",
-                "options": [],
-                "query": "label_values(app)",
-                "refresh": 1,
-                "regex": "",
-                "sort": 1,
-                "tagValuesQuery": null,
-                "tags": [],
-                "tagsQuery": null,
-                "type": "query",
-                "useTags": false
-            },
-            {
-                "current": {
-                    "text": "Prometheus App Metrics",
-                    "value": "Prometheus App Metrics"
-                },
-                "hide": 0,
-                "label": null,
-                "name": "datasource",
-                "options": [],
-                "query": "prometheus",
-                "refresh": 1,
-                "regex": "",
-                "type": "datasource"
-            },
-            {
-                "auto": false,
-                "auto_count": 30,
-                "auto_min": "10s",
-                "current": {
-                    "text": "5s",
-                    "value": "5s"
-                },
-                "hide": 0,
-                "label": null,
-                "name": "summarize",
-                "options": [
-                    {
-                        "selected": true,
-                        "text": "5s",
-                        "value": "5s"
-                    },
-                    {
-                        "selected": false,
-                        "text": "10s",
-                        "value": "10s"
-                    },
-                    {
-                        "selected": false,
-                        "text": "30s",
-                        "value": "30s"
-                    },
-                    {
-                        "selected": false,
-                        "text": "1m",
-                        "value": "1m"
-                    },
-                    {
-                        "selected": false,
-                        "text": "10m",
-                        "value": "10m"
-                    },
-                    {
-                        "selected": false,
-                        "text": "30m",
-                        "value": "30m"
-                    },
-                    {
-                        "selected": false,
-                        "text": "1h",
-                        "value": "1h"
-                    },
-                    {
-                        "selected": false,
-                        "text": "6h",
-                        "value": "6h"
-                    },
-                    {
-                        "selected": false,
-                        "text": "12h",
-                        "value": "12h"
-                    },
-                    {
-                        "selected": false,
-                        "text": "1d",
-                        "value": "1d"
-                    },
-                    {
-                        "selected": false,
-                        "text": "7d",
-                        "value": "7d"
-                    },
-                    {
-                        "selected": false,
-                        "text": "14d",
-                        "value": "14d"
-                    },
-                    {
-                        "selected": false,
-                        "text": "30d",
-                        "value": "30d"
-                    }
-                ],
-                "query": "5s,10s,30s,1m,10m,30m,1h,6h,12h,1d,7d,14d,30d",
-                "refresh": 2,
-                "type": "interval"
-            },
-            {
-                "allValue": null,
-                "current": {
-                    "text": "All",
-                    "value": "$__all"
-                },
-                "datasource": "Prometheus App Metrics",
-                "hide": 0,
-                "includeAll": true,
-                "label": null,
-                "multi": true,
-                "name": "server",
-                "options": [],
-                "query": "label_values(server)",
-                "refresh": 1,
-                "regex": "",
-                "sort": 0,
-                "tagValuesQuery": "",
-                "tags": [],
-                "tagsQuery": "",
-                "type": "query",
-                "useTags": false
+              "name": "range to text",
+              "value": 2
             }
-        ]
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 2,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": true,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": true
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "dsType": "influxdb",
+              "expr": "sum(rate(application_httprequests_transactions_count{env=\"$environment\",app=\"$application\",server=~\"$server\"}[1m]))*60",
+              "format": "time_series",
+              "groupBy": [
+                {
+                  "params": [
+                    "$interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "intervalFactor": 1,
+              "measurement": "application.httprequests__transactions",
+              "metric": "",
+              "policy": "default",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "rate1m"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "last"
+                  }
+                ]
+              ],
+              "step": 2,
+              "tags": [
+                {
+                  "key": "app",
+                  "operator": "=~",
+                  "value": "/^$application$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "env",
+                  "operator": "=~",
+                  "value": "/^$environment$/"
+                }
+              ]
+            }
+          ],
+          "thresholds": "",
+          "title": "Throughput",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "rgba(50, 172, 45, 0.97)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(245, 54, 54, 0.9)"
+          ],
+          "datasource": "$datasource",
+          "decimals": 4,
+          "editable": true,
+          "error": false,
+          "format": "percent",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 6,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "",
+              "text": "",
+              "to": ""
+            }
+          ],
+          "span": 2,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": true,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": true
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "dsType": "influxdb",
+              "expr": "avg(application_httprequests_one_minute_error_percentage_rate{env=\"$environment\",app=\"$application\",server=~\"$server\"})",
+              "format": "time_series",
+              "groupBy": [],
+              "intervalFactor": 2,
+              "legendFormat": "",
+              "measurement": "application.httprequests__one_minute_error_percentage_rate",
+              "policy": "default",
+              "query": "SELECT  \"value\" FROM \"application.httprequests__percentage_error_requests\" WHERE $timeFilter",
+              "rawQuery": false,
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  }
+                ]
+              ],
+              "step": 4,
+              "tags": [
+                {
+                  "key": "env",
+                  "operator": "=~",
+                  "value": "/^$environment$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "app",
+                  "operator": "=~",
+                  "value": "/^$application$/"
+                }
+              ]
+            }
+          ],
+          "thresholds": "",
+          "title": "Error %",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "0%",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$datasource",
+          "editable": true,
+          "error": false,
+          "fill": 2,
+          "id": 13,
+          "interval": "$summarize",
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": false,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "",
+              "dsType": "influxdb",
+              "expr": "sum(application_httprequests_active{env=\"$environment\",app=\"$application\",server=~\"$server\"})",
+              "format": "time_series",
+              "groupBy": [
+                {
+                  "params": [
+                    "$interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "intervalFactor": 2,
+              "legendFormat": "",
+              "measurement": "application.httprequests__active",
+              "policy": "default",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "last"
+                  }
+                ]
+              ],
+              "step": 10,
+              "tags": [
+                {
+                  "key": "env",
+                  "operator": "=~",
+                  "value": "/^$environment$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "app",
+                  "operator": "=~",
+                  "value": "/^$application$/"
+                }
+              ]
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Active Requests",
+          "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {
+            "application.httprequests__apdex.last": "#6ED0E0"
+          },
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$datasource",
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "height": "",
+          "id": 7,
+          "interval": "$summarize",
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": false,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 3,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "dsType": "influxdb",
+              "expr": "avg(application_httprequests_apdex{env=\"$environment\",app=\"$application\",server=~\"$server\"})",
+              "format": "time_series",
+              "groupBy": [
+                {
+                  "params": [
+                    "$interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "intervalFactor": 2,
+              "measurement": "application.httprequests__apdex",
+              "metric": "application_httprequests_apdex",
+              "policy": "default",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "score"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "last"
+                  }
+                ]
+              ],
+              "step": 10,
+              "tags": [
+                {
+                  "key": "app",
+                  "operator": "=~",
+                  "value": "/^$application$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "env",
+                  "operator": "=~",
+                  "value": "/^$environment$/"
+                }
+              ]
+            }
+          ],
+          "thresholds": [
+            {
+              "colorMode": "critical",
+              "fill": true,
+              "line": true,
+              "op": "lt",
+              "value": 0.5
+            },
+            {
+              "colorMode": "warning",
+              "fill": true,
+              "line": true,
+              "op": "gt",
+              "value": 0.5
+            },
+            {
+              "colorMode": "ok",
+              "fill": true,
+              "line": true,
+              "op": "gt",
+              "value": 0.75
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Apdex score",
+          "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": "apdex",
+              "logBase": 1,
+              "max": "1",
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$datasource",
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "height": "350",
+          "id": 1,
+          "interval": "$summarize",
+          "legend": {
+            "avg": false,
+            "current": true,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "$col",
+              "dsType": "influxdb",
+              "expr": "sum(rate(application_httprequests_transactions_count{env=\"$environment\",app=\"$application\",server=~\"$server\"}[1m]))*60",
+              "format": "time_series",
+              "groupBy": [
+                {
+                  "params": [
+                    "$interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "intervalFactor": 2,
+              "legendFormat": "1 min rate",
+              "measurement": "application.httprequests__transactions",
+              "policy": "default",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "rate1m"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "last"
+                  },
+                  {
+                    "params": [
+                      "1 min rate"
+                    ],
+                    "type": "alias"
+                  }
+                ],
+                [
+                  {
+                    "params": [
+                      "rate5m"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "last"
+                  },
+                  {
+                    "params": [
+                      "5 min rate"
+                    ],
+                    "type": "alias"
+                  }
+                ],
+                [
+                  {
+                    "params": [
+                      "rate15m"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "last"
+                  },
+                  {
+                    "params": [
+                      "15 min rate"
+                    ],
+                    "type": "alias"
+                  }
+                ]
+              ],
+              "step": 10,
+              "tags": [
+                {
+                  "key": "env",
+                  "operator": "=~",
+                  "value": "/^$environment$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "app",
+                  "operator": "=~",
+                  "value": "/^$application$/"
+                }
+              ]
+            },
+            {
+              "expr": "sum(rate(application_httprequests_transactions_count{env=\"$environment\",app=\"$application\",server=~\"$server\"}[5m]))*60",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "5 min rate",
+              "refId": "B",
+              "step": 10
+            },
+            {
+              "expr": "sum(irate(application_httprequests_transactions_count{env=\"$environment\",app=\"$application\",server=~\"$server\"}[15m]))*60",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "15 min rate",
+              "refId": "C",
+              "step": 10
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Throughput",
+          "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "rpm",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$datasource",
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "height": "350",
+          "id": 2,
+          "interval": "$summarize",
+          "legend": {
+            "alignAsTable": false,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "$col",
+              "dsType": "influxdb",
+              "expr": "avg(application_httprequests_transactions{env=\"$environment\",app=\"$application\",server=~\"$server\",quantile=\"0.75\"})",
+              "format": "time_series",
+              "groupBy": [
+                {
+                  "params": [
+                    "$interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "intervalFactor": 2,
+              "legendFormat": "75th Percentile",
+              "measurement": "application.httprequests__transactions",
+              "metric": "",
+              "policy": "default",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "p95"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "last"
+                  },
+                  {
+                    "params": [
+                      "95th Percentile"
+                    ],
+                    "type": "alias"
+                  }
+                ],
+                [
+                  {
+                    "params": [
+                      "p98"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "last"
+                  },
+                  {
+                    "params": [
+                      "98th Percentile"
+                    ],
+                    "type": "alias"
+                  }
+                ],
+                [
+                  {
+                    "params": [
+                      "p99"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "last"
+                  },
+                  {
+                    "params": [
+                      "99th Percentile"
+                    ],
+                    "type": "alias"
+                  }
+                ]
+              ],
+              "step": 10,
+              "tags": [
+                {
+                  "key": "env",
+                  "operator": "=~",
+                  "value": "/^$environment$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "app",
+                  "operator": "=~",
+                  "value": "/^$application$/"
+                }
+              ]
+            },
+            {
+              "expr": "avg(application_httprequests_transactions{env=\"$environment\",app=\"$application\",server=~\"$server\",quantile=\"0.95\"})",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "95th Percentile",
+              "refId": "B",
+              "step": 10
+            },
+            {
+              "expr": "avg(application_httprequests_transactions{env=\"$environment\",app=\"$application\",server=~\"$server\",quantile=\"0.99\"})",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "99th Percentile",
+              "refId": "C",
+              "step": 10
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Response Time",
+          "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "s",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$datasource",
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "height": "",
+          "id": 9,
+          "interval": "$summarize",
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": false,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "",
+              "dsType": "influxdb",
+              "expr": "application_httprequests_one_minute_error_percentage_rate{env=\"$environment\",app=\"$application\",server=~\"$server\"}",
+              "format": "time_series",
+              "groupBy": [
+                {
+                  "params": [
+                    "$interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "intervalFactor": 2,
+              "legendFormat": "",
+              "measurement": "application.httprequests__one_minute_error_percentage_rate",
+              "policy": "default",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "last"
+                  }
+                ]
+              ],
+              "step": 10,
+              "tags": [
+                {
+                  "key": "app",
+                  "operator": "=~",
+                  "value": "/^$application$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "env",
+                  "operator": "=~",
+                  "value": "/^$environment$/"
+                }
+              ]
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Error Rate %",
+          "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "percent",
+              "label": null,
+              "logBase": 1,
+              "max": "100",
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "cacheTimeout": null,
+          "combine": {
+            "label": "Others",
+            "threshold": 0
+          },
+          "datasource": "$datasource",
+          "editable": true,
+          "error": false,
+          "fontSize": "80%",
+          "format": "percent",
+          "height": "250px",
+          "id": 4,
+          "interval": "",
+          "legend": {
+            "percentage": true,
+            "show": true,
+            "sort": null,
+            "sortDesc": null,
+            "values": true
+          },
+          "legendType": "Right side",
+          "links": [],
+          "maxDataPoints": 3,
+          "nullPointMode": "connected",
+          "pieType": "pie",
+          "span": 3,
+          "strokeWidth": 1,
+          "targets": [
+            {
+              "alias": "$tag_http_status_code",
+              "dsType": "influxdb",
+              "expr": "sum(application_httprequests_errors{env=\"$environment\",app=\"$application\",server=~\"$server\"}) without (server)",
+              "format": "time_series",
+              "groupBy": [
+                {
+                  "params": [
+                    "http_status_code"
+                  ],
+                  "type": "tag"
+                }
+              ],
+              "intervalFactor": 2,
+              "legendFormat": "{{http_status_code}}",
+              "measurement": "application.httprequests__errors",
+              "policy": "default",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "sum"
+                  }
+                ]
+              ],
+              "step": 240,
+              "tags": [
+                {
+                  "key": "app",
+                  "operator": "=~",
+                  "value": "/^$application$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "env",
+                  "operator": "=~",
+                  "value": "/^$environment$/"
+                }
+              ]
+            }
+          ],
+          "title": "Errors",
+          "type": "grafana-piechart-panel",
+          "valueName": "current"
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$datasource",
+          "decimals": 2,
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "height": "250px",
+          "id": 3,
+          "interval": "$summarize",
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 5,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "$col",
+              "dsType": "influxdb",
+              "expr": "sum(rate(application_httprequests_error_rate_total[1m]))*60",
+              "format": "time_series",
+              "groupBy": [
+                {
+                  "params": [
+                    "$interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "intervalFactor": 2,
+              "legendFormat": "1min rate",
+              "measurement": "application.httprequests__error_rate",
+              "policy": "default",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "rate1m"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "last"
+                  },
+                  {
+                    "params": [
+                      "1min rate"
+                    ],
+                    "type": "alias"
+                  }
+                ],
+                [
+                  {
+                    "params": [
+                      "rate5m"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "last"
+                  },
+                  {
+                    "params": [
+                      "5min rate"
+                    ],
+                    "type": "alias"
+                  }
+                ],
+                [
+                  {
+                    "params": [
+                      "rate15m"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "last"
+                  },
+                  {
+                    "params": [
+                      "15min rate"
+                    ],
+                    "type": "alias"
+                  }
+                ]
+              ],
+              "step": 10,
+              "tags": [
+                {
+                  "key": "app",
+                  "operator": "=~",
+                  "value": "/^$application$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "env",
+                  "operator": "=~",
+                  "value": "/^$environment$/"
+                }
+              ]
+            },
+            {
+              "expr": "sum(rate(application_httprequests_error_rate_total[5m]))*60",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "5min rate",
+              "refId": "B",
+              "step": 10
+            },
+            {
+              "expr": "sum(rate(application_httprequests_error_rate_total[15m]))*60",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "15min rate",
+              "refId": "C",
+              "step": 10
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Error Rate",
+          "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "rpm",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": true,
+      "title": "Overview",
+      "titleSize": "h6"
     },
-    "time": {
-        "from": "now-5m",
-        "to": "now"
+    {
+      "collapse": false,
+      "height": "300",
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$datasource",
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "height": "350",
+          "id": 16,
+          "interval": "$summarize",
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": true,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "$tag_route",
+              "dsType": "influxdb",
+              "expr": "sum(rate(application_httprequests_transactions_per_endpoint_count{env=\"$environment\",app=\"$application\",server=~\"$server\"}[1m])*60) without (server)",
+              "format": "time_series",
+              "groupBy": [
+                {
+                  "params": [
+                    "$interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "route"
+                  ],
+                  "type": "tag"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "intervalFactor": 2,
+              "legendFormat": "{{route}}",
+              "measurement": "application.httprequests__transactions_per_endpoint",
+              "policy": "default",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "rate1m"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "last"
+                  }
+                ]
+              ],
+              "step": 10,
+              "tags": [
+                {
+                  "key": "env",
+                  "operator": "=~",
+                  "value": "/^$environment$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "app",
+                  "operator": "=~",
+                  "value": "/^$application$/"
+                }
+              ]
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Throughput / Endpoint",
+          "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "transparent": false,
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "rpm",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$datasource",
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "height": "350",
+          "id": 17,
+          "interval": "$summarize",
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "$tag_route",
+              "dsType": "influxdb",
+              "expr": "avg(application_httprequests_transactions_per_endpoint{env=\"$environment\",app=\"$application\",quantile=\"0.95\"}) without (server)",
+              "format": "time_series",
+              "groupBy": [
+                {
+                  "params": [
+                    "$interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "route"
+                  ],
+                  "type": "tag"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "intervalFactor": 2,
+              "legendFormat": "{{route}}",
+              "measurement": "application.httprequests__transactions_per_endpoint",
+              "policy": "default",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "p95"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "last"
+                  },
+                  {
+                    "params": [
+                      "95th Percentile"
+                    ],
+                    "type": "alias"
+                  }
+                ]
+              ],
+              "step": 10,
+              "tags": [
+                {
+                  "key": "env",
+                  "operator": "=~",
+                  "value": "/^$environment$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "app",
+                  "operator": "=~",
+                  "value": "/^$application$/"
+                }
+              ]
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Response Time / Endpoint",
+          "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "s",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "columns": [
+            {
+              "text": "Current",
+              "value": "current"
+            }
+          ],
+          "datasource": "$datasource",
+          "editable": true,
+          "error": false,
+          "filterNull": false,
+          "fontSize": "100%",
+          "id": 10,
+          "interval": "",
+          "links": [],
+          "pageSize": null,
+          "scroll": true,
+          "showHeader": true,
+          "sort": {
+            "col": 1,
+            "desc": true
+          },
+          "span": 4,
+          "styles": [
+            {
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "pattern": "Time",
+              "type": "date"
+            },
+            {
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "decimals": 2,
+              "pattern": "/.*/",
+              "thresholds": [],
+              "type": "number",
+              "unit": "ms"
+            }
+          ],
+          "targets": [
+            {
+              "alias": "$tag_route",
+              "dsType": "influxdb",
+              "expr": "application_httprequests_transactions_per_endpoint{env=\"$environment\",app=\"$application\",server=\"$server\",quantile=\"0.95\"}",
+              "groupBy": [
+                {
+                  "params": [
+                    "$interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "route"
+                  ],
+                  "type": "tag"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "intervalFactor": 2,
+              "legendFormat": "{{route}}",
+              "measurement": "application.httprequests__transactions_per_endpoint",
+              "policy": "default",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "p95"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "last"
+                  }
+                ]
+              ],
+              "step": 2,
+              "tags": [
+                {
+                  "key": "env",
+                  "operator": "=~",
+                  "value": "/^$environment$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "app",
+                  "operator": "=~",
+                  "value": "/^$application$/"
+                }
+              ]
+            }
+          ],
+          "title": "Response Times / Endpoint",
+          "transform": "timeseries_aggregations",
+          "type": "table"
+        },
+        {
+          "columns": [
+            {
+              "text": "Current",
+              "value": "current"
+            }
+          ],
+          "datasource": "$datasource",
+          "editable": true,
+          "error": false,
+          "filterNull": false,
+          "fontSize": "100%",
+          "id": 11,
+          "interval": "",
+          "links": [],
+          "pageSize": null,
+          "scroll": true,
+          "showHeader": true,
+          "sort": {
+            "col": null,
+            "desc": false
+          },
+          "span": 4,
+          "styles": [
+            {
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "pattern": "Time",
+              "type": "date"
+            },
+            {
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "decimals": 0,
+              "pattern": "/.*/",
+              "thresholds": [],
+              "type": "number",
+              "unit": "percent"
+            }
+          ],
+          "targets": [
+            {
+              "alias": "$tag_route",
+              "dsType": "influxdb",
+              "expr": "application_httprequests_one_minute_error_percentage_rate_per_endpoint{env=\"$environment\",app=\"$application\",server=\"$server\"}",
+              "groupBy": [
+                {
+                  "params": [
+                    "$interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "route"
+                  ],
+                  "type": "tag"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "intervalFactor": 2,
+              "legendFormat": "{{route}}",
+              "measurement": "application.httprequests__one_minute_error_percentage_rate_per_endpoint",
+              "policy": "default",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "last"
+                  }
+                ]
+              ],
+              "step": 2,
+              "tags": [
+                {
+                  "key": "app",
+                  "operator": "=~",
+                  "value": "/^$application$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "env",
+                  "operator": "=~",
+                  "value": "/^$environment$/"
+                }
+              ]
+            }
+          ],
+          "title": "Error Request Percentage / Endpoint",
+          "transform": "timeseries_aggregations",
+          "type": "table"
+        },
+        {
+          "columns": [
+            {
+              "text": "Current",
+              "value": "current"
+            }
+          ],
+          "datasource": "$datasource",
+          "editable": true,
+          "error": false,
+          "filterNull": false,
+          "fontSize": "100%",
+          "id": 12,
+          "interval": "",
+          "links": [],
+          "pageSize": null,
+          "scroll": true,
+          "showHeader": true,
+          "sort": {
+            "col": 1,
+            "desc": true
+          },
+          "span": 4,
+          "styles": [
+            {
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "pattern": "Time",
+              "type": "date"
+            },
+            {
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "decimals": 2,
+              "pattern": "/.*/",
+              "thresholds": [],
+              "type": "number",
+              "unit": "rpm"
+            }
+          ],
+          "targets": [
+            {
+              "alias": "$tag_route",
+              "dsType": "influxdb",
+              "expr": "rate(application_httprequests_transactions_per_endpoint_count{env=\"$environment\",app=\"$application\",server=\"$server\"}[1m])*60",
+              "groupBy": [
+                {
+                  "params": [
+                    "$interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "route"
+                  ],
+                  "type": "tag"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "intervalFactor": 2,
+              "legendFormat": "{{route}}",
+              "measurement": "application.httprequests__transactions_per_endpoint",
+              "policy": "default",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "rate1m"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "last"
+                  }
+                ]
+              ],
+              "step": 2,
+              "tags": [
+                {
+                  "key": "env",
+                  "operator": "=~",
+                  "value": "/^$environment$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "app",
+                  "operator": "=~",
+                  "value": "/^$application$/"
+                }
+              ]
+            }
+          ],
+          "title": "Throughput / Endpoint",
+          "transform": "timeseries_aggregations",
+          "type": "table"
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": true,
+      "title": "Endpoints",
+      "titleSize": "h6"
     },
-    "timepicker": {
-        "refresh_intervals": [
-            "5s",
-            "10s",
-            "30s",
-            "1m",
-            "5m",
-            "15m",
-            "30m",
-            "1h",
-            "2h",
-            "1d"
+    {
+      "collapse": false,
+      "height": "250",
+      "panels": [
+        {
+          "columns": [
+            {
+              "text": "Current",
+              "value": "current"
+            }
+          ],
+          "datasource": "$datasource",
+          "editable": true,
+          "error": false,
+          "filterNull": false,
+          "fontSize": "100%",
+          "hideTimeOverride": true,
+          "id": 22,
+          "interval": "",
+          "links": [],
+          "pageSize": null,
+          "scroll": true,
+          "showHeader": true,
+          "sort": {
+            "col": 0,
+            "desc": true
+          },
+          "span": 9,
+          "styles": [
+            {
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "pattern": "Time",
+              "type": "date"
+            },
+            {
+              "colorMode": "row",
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "decimals": 1,
+              "pattern": "/.*/",
+              "thresholds": [
+                "0.5",
+                "1"
+              ],
+              "type": "number",
+              "unit": "short"
+            }
+          ],
+          "targets": [
+            {
+              "alias": "$tag_health_check_name",
+              "dsType": "influxdb",
+              "expr": "application_health_results{env=\"stage\",app=\"$application\",server=\"$server\"}",
+              "groupBy": [
+                {
+                  "params": [
+                    "$interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "health_check_name"
+                  ],
+                  "type": "tag"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "intervalFactor": 2,
+              "legendFormat": "{{health_check_name}}",
+              "measurement": "application.health__results",
+              "metric": "application_health_results",
+              "policy": "default",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "last"
+                  }
+                ]
+              ],
+              "step": 2,
+              "tags": [
+                {
+                  "key": "env",
+                  "operator": "=~",
+                  "value": "/^$environment$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "app",
+                  "operator": "=~",
+                  "value": "/^$application$/"
+                }
+              ]
+            }
+          ],
+          "timeFrom": null,
+          "title": "Results",
+          "transform": "timeseries_aggregations",
+          "transparent": true,
+          "type": "table"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": true,
+          "colorValue": false,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "datasource": "$datasource",
+          "editable": true,
+          "error": false,
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "hideTimeOverride": true,
+          "id": 19,
+          "interval": null,
+          "links": [
+            {
+              "type": "dashboard"
+            }
+          ],
+          "mappingType": 2,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "0",
+              "text": "Unhealthy",
+              "to": "0.49"
+            },
+            {
+              "from": "0.5",
+              "text": "Degraded",
+              "to": "0.9"
+            },
+            {
+              "from": "1.0",
+              "text": "Healthy",
+              "to": "2.0"
+            }
+          ],
+          "span": 3,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "dsType": "influxdb",
+              "expr": "application_health_score{env=\"stage\",app=\"$application\",server=\"$server\"}",
+              "groupBy": [
+                {
+                  "params": [
+                    "$interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "intervalFactor": 2,
+              "measurement": "application.health__score",
+              "metric": "application_health_score",
+              "policy": "default",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "last"
+                  }
+                ]
+              ],
+              "step": 4,
+              "tags": [
+                {
+                  "key": "env",
+                  "operator": "=~",
+                  "value": "/^$environment$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "app",
+                  "operator": "=~",
+                  "value": "/^$application$/"
+                }
+              ]
+            }
+          ],
+          "thresholds": "0.5,1",
+          "timeFrom": null,
+          "title": "",
+          "transparent": true,
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "Unhealthy",
+              "value": "0"
+            },
+            {
+              "op": "=",
+              "text": "Degraded",
+              "value": "0.5"
+            },
+            {
+              "op": "=",
+              "text": "Healthy",
+              "value": "1.0"
+            }
+          ],
+          "valueName": "current"
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": true,
+      "title": "Health",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": "300",
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$datasource",
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "id": 14,
+          "interval": "$summarize",
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": false,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "$col",
+              "dsType": "influxdb",
+              "expr": "avg(application_httprequests_post_size{env=\"$environment\",app=\"$application\",server=~\"$server\",quantile=\"0.75\"}) without (server)",
+              "format": "time_series",
+              "groupBy": [
+                {
+                  "params": [
+                    "$interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "intervalFactor": 2,
+              "legendFormat": "75th Percentile",
+              "measurement": "application.httprequests__post_size",
+              "policy": "default",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "p95"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "last"
+                  },
+                  {
+                    "params": [
+                      "95th percentile"
+                    ],
+                    "type": "alias"
+                  }
+                ],
+                [
+                  {
+                    "params": [
+                      "p98"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "last"
+                  },
+                  {
+                    "params": [
+                      "98th percentile"
+                    ],
+                    "type": "alias"
+                  }
+                ],
+                [
+                  {
+                    "params": [
+                      "p99"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "last"
+                  },
+                  {
+                    "params": [
+                      "99th percentile"
+                    ],
+                    "type": "alias"
+                  }
+                ],
+                [
+                  {
+                    "params": [
+                      "last"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "median"
+                  },
+                  {
+                    "params": [
+                      "median"
+                    ],
+                    "type": "alias"
+                  }
+                ]
+              ],
+              "step": 10,
+              "tags": [
+                {
+                  "key": "app",
+                  "operator": "=~",
+                  "value": "/^$application$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "env",
+                  "operator": "=~",
+                  "value": "/^$environment$/"
+                }
+              ]
+            },
+            {
+              "expr": "avg(application_httprequests_post_size{env=\"$environment\",app=\"$application\",server=~\"$server\",quantile=\"0.95\"}) without (server)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "95th Percentile",
+              "refId": "B",
+              "step": 10
+            },
+            {
+              "expr": "avg(application_httprequests_post_size{env=\"$environment\",app=\"$application\",server=~\"$server\",quantile=\"0.99\"}) without (server)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "99th Percentile",
+              "refId": "C",
+              "step": 10
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Post Request Size",
+          "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "decbytes",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$datasource",
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "id": 15,
+          "interval": "$summarize",
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "$col",
+              "dsType": "influxdb",
+              "expr": "avg(application_httprequests_put_size{env=\"$environment\",app=\"$application\",server=~\"$server\",quantile=\"0.75\"}) without (server,kubernetes_pod_name,instance)",
+              "format": "time_series",
+              "groupBy": [
+                {
+                  "params": [
+                    "$interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "intervalFactor": 2,
+              "legendFormat": "75th Percentile",
+              "measurement": "application.httprequests__put_size",
+              "policy": "default",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "p95"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "last"
+                  },
+                  {
+                    "params": [
+                      "95th percentile"
+                    ],
+                    "type": "alias"
+                  }
+                ],
+                [
+                  {
+                    "params": [
+                      "p98"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "last"
+                  },
+                  {
+                    "params": [
+                      "98th percentile"
+                    ],
+                    "type": "alias"
+                  }
+                ],
+                [
+                  {
+                    "params": [
+                      "p99"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "last"
+                  },
+                  {
+                    "params": [
+                      "99th percentile"
+                    ],
+                    "type": "alias"
+                  }
+                ],
+                [
+                  {
+                    "params": [
+                      "median"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "median"
+                  },
+                  {
+                    "params": [
+                      "median"
+                    ],
+                    "type": "alias"
+                  }
+                ]
+              ],
+              "step": 10,
+              "tags": [
+                {
+                  "key": "app",
+                  "operator": "=~",
+                  "value": "/^$application$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "env",
+                  "operator": "=~",
+                  "value": "/^$environment$/"
+                }
+              ]
+            },
+            {
+              "expr": "avg(application_httprequests_put_size{env=\"$environment\",app=\"$application\",server=~\"$server\",quantile=\"0.95\"}) without (server,kubernetes_pod_name,instance)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "95th Percentile",
+              "refId": "B",
+              "step": 10
+            },
+            {
+              "expr": "avg(application_httprequests_put_size{env=\"$environment\",app=\"$application\",server=~\"$server\",quantile=\"0.99\"}) without (server,kubernetes_pod_name,instance)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "99th Percentile",
+              "refId": "C",
+              "step": 10
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Put Request Size",
+          "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "bytes",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": true,
+      "title": "PUT & POST Request Size",
+      "titleSize": "h6"
+    }
+  ],
+  "schemaVersion": 14,
+  "style": "dark",
+  "tags": [
+    "prometheus"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {
+          "text": "release",
+          "value": "release"
+        },
+        "datasource": "$datasource",
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "environment",
+        "options": [],
+        "query": "label_values(env)",
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "tagValuesQuery": null,
+        "tags": [],
+        "tagsQuery": null,
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "tags": [],
+          "text": "appcatalog",
+          "value": "appcatalog"
+        },
+        "datasource": "$datasource",
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "application",
+        "options": [],
+        "query": "label_values(app)",
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "tagValuesQuery": null,
+        "tags": [],
+        "tagsQuery": null,
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "current": {
+          "text": "prometheus",
+          "value": "prometheus"
+        },
+        "hide": 0,
+        "label": null,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
+      {
+        "auto": false,
+        "auto_count": 30,
+        "auto_min": "10s",
+        "current": {
+          "text": "5s",
+          "value": "5s"
+        },
+        "hide": 0,
+        "label": null,
+        "name": "summarize",
+        "options": [
+          {
+            "selected": true,
+            "text": "5s",
+            "value": "5s"
+          },
+          {
+            "selected": false,
+            "text": "10s",
+            "value": "10s"
+          },
+          {
+            "selected": false,
+            "text": "30s",
+            "value": "30s"
+          },
+          {
+            "selected": false,
+            "text": "1m",
+            "value": "1m"
+          },
+          {
+            "selected": false,
+            "text": "10m",
+            "value": "10m"
+          },
+          {
+            "selected": false,
+            "text": "30m",
+            "value": "30m"
+          },
+          {
+            "selected": false,
+            "text": "1h",
+            "value": "1h"
+          },
+          {
+            "selected": false,
+            "text": "6h",
+            "value": "6h"
+          },
+          {
+            "selected": false,
+            "text": "12h",
+            "value": "12h"
+          },
+          {
+            "selected": false,
+            "text": "1d",
+            "value": "1d"
+          },
+          {
+            "selected": false,
+            "text": "7d",
+            "value": "7d"
+          },
+          {
+            "selected": false,
+            "text": "14d",
+            "value": "14d"
+          },
+          {
+            "selected": false,
+            "text": "30d",
+            "value": "30d"
+          }
         ],
-        "time_options": [
-            "5m",
-            "15m",
-            "1h",
-            "6h",
-            "12h",
-            "24h",
-            "2d",
-            "7d",
-            "30d"
-        ]
-    },
-    "timezone": "browser",
-    "title": "App Metrics - Web Monitoring - Prometheus",
-    "version": 5
+        "query": "5s,10s,30s,1m,10m,30m,1h,6h,12h,1d,7d,14d,30d",
+        "refresh": 2,
+        "type": "interval"
+      },
+      {
+        "allValue": null,
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": "prometheus",
+        "hide": 0,
+        "includeAll": true,
+        "label": null,
+        "multi": true,
+        "name": "server",
+        "options": [],
+        "query": "label_values(server)",
+        "refresh": 1,
+        "regex": "",
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-5m",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "browser",
+  "title": "App Metrics - Web Monitoring - Prometheus",
+  "version": 1
 }


### PR DESCRIPTION
## Adjust the Prometheus-Grafana dashboard to aggregate the metrics from multiple server instances

Addresses #9

### Details on the issue fix or feature implementation

I changed the metric queries for all of the graphs so that they use an appropriate aggregation, for example a `sum` for the throughput and an `avg` for the response time.

I didn't touch the Table Panels, because I couldn't get them to work at all (I can't even find any examples out there with Prometheus + Tables).

The diff is super ugly, I don't know how this could be avoided, I guess when I exported the json from Grafana, it changed the ordering in the Json for some reason.

### Confirm the following

- [ N/A ] I have ensured that I have merged the latest changes from the dev branch
- [ N/A ] I have successfully run a [local build](https://github.com/alhardy/AppMetrics#how-to-build)
- [ N/A ] I have included unit tests for the issue/feature
- [ x ] I have included the github issue number in my commits 