### PR TITLE
#20 Add options to override line endings characters for MetricsPrometheus…

### DIFF
--- a/src/App.Metrics.Formatters.Prometheus/Internal/AsciiFormatter.cs
+++ b/src/App.Metrics.Formatters.Prometheus/Internal/AsciiFormatter.cs
@@ -2,6 +2,7 @@
 // Copyright (c) Allan Hardy. All rights reserved.
 // </copyright>
 
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -25,13 +26,13 @@ namespace App.Metrics.Formatters.Prometheus.Internal
             }
         }
 
-        internal static string Format(IEnumerable<MetricFamily> metrics)
+        internal static string Format(IEnumerable<MetricFamily> metrics, NewLineFormat newLine)
         {
             var metricFamilys = metrics.ToArray();
             var s = new StringBuilder();
             foreach (var metricFamily in metricFamilys)
             {
-                s.Append(WriteFamily(metricFamily));
+                s.Append(WriteFamily(metricFamily, newLine));
             }
 
             return s.ToString();
@@ -47,14 +48,14 @@ namespace App.Metrics.Formatters.Prometheus.Internal
             }
         }
 
-        private static string WriteFamily(MetricFamily metricFamily)
+        private static string WriteFamily(MetricFamily metricFamily, NewLineFormat newLine)
         {
             var s = new StringBuilder();
-            s.AppendLine(string.Format("# HELP {0} {1}", metricFamily.name, metricFamily.help));
-            s.AppendLine(string.Format("# TYPE {0} {1}", metricFamily.name, metricFamily.type));
+            s.Append(string.Format("# HELP {0} {1}", metricFamily.name, metricFamily.help), newLine);
+            s.Append(string.Format("# TYPE {0} {1}", metricFamily.name, metricFamily.type), newLine);
             foreach (var metric in metricFamily.metric)
             {
-                s.AppendLine(WriteMetric(metricFamily, metric));
+                s.Append(WriteMetric(metricFamily, metric, newLine), newLine);
             }
 
             return s.ToString();
@@ -110,49 +111,49 @@ namespace App.Metrics.Formatters.Prometheus.Internal
             }
         }
 
-        private static string WriteMetric(MetricFamily family, Metric metric)
+        private static string WriteMetric(MetricFamily family, Metric metric, NewLineFormat newLine)
         {
             var s = new StringBuilder();
             var familyName = family.name;
 
             if (metric.gauge != null)
             {
-                s.AppendLine(SimpleValue(familyName, metric.gauge.value, metric.label));
+                s.Append(SimpleValue(familyName, metric.gauge.value, metric.label), newLine);
             }
             else if (metric.counter != null)
             {
-                s.AppendLine(SimpleValue(familyName, metric.counter.value, metric.label));
+                s.Append(SimpleValue(familyName, metric.counter.value, metric.label), newLine);
             }
             else if (metric.summary != null)
             {
-                s.AppendLine(SimpleValue(familyName, metric.summary.sample_sum, metric.label, "_sum"));
-                s.AppendLine(SimpleValue(familyName, metric.summary.sample_count, metric.label, "_count"));
+                s.Append(SimpleValue(familyName, metric.summary.sample_sum, metric.label, "_sum"), newLine);
+                s.Append(SimpleValue(familyName, metric.summary.sample_count, metric.label, "_count"), newLine);
 
                 foreach (var quantileValuePair in metric.summary.quantile)
                 {
                     var quantile = double.IsPositiveInfinity(quantileValuePair.quantile)
                         ? "+Inf"
                         : quantileValuePair.quantile.ToString(CultureInfo.InvariantCulture);
-                    s.AppendLine(
+                    s.Append(
                         SimpleValue(
                             familyName,
                             quantileValuePair.value,
-                            metric.label.Concat(new[] { new LabelPair { name = "quantile", value = quantile } })));
+                            metric.label.Concat(new[] { new LabelPair { name = "quantile", value = quantile } })), newLine);
                 }
             }
             else if (metric.histogram != null)
             {
-                s.AppendLine(SimpleValue(familyName, metric.histogram.sample_sum, metric.label, "_sum"));
-                s.AppendLine(SimpleValue(familyName, metric.histogram.sample_count, metric.label, "_count"));
+                s.Append(SimpleValue(familyName, metric.histogram.sample_sum, metric.label, "_sum"), newLine);
+                s.Append(SimpleValue(familyName, metric.histogram.sample_count, metric.label, "_count"), newLine);
                 foreach (var bucket in metric.histogram.bucket)
                 {
                     var value = double.IsPositiveInfinity(bucket.upper_bound) ? "+Inf" : bucket.upper_bound.ToString(CultureInfo.InvariantCulture);
-                    s.AppendLine(
+                    s.Append(
                         SimpleValue(
                             familyName,
                             bucket.cumulative_count,
                             metric.label.Concat(new[] { new LabelPair { name = "le", value = value } }),
-                            "_bucket"));
+                            "_bucket"), newLine);
                 }
             }
             else
@@ -178,6 +179,24 @@ namespace App.Metrics.Formatters.Prometheus.Internal
         private static string SimpleValue(string family, double value, IEnumerable<LabelPair> labels, string namePostfix = null)
         {
             return string.Format("{0} {1}", WithLabels(family + (namePostfix ?? string.Empty), labels), value.ToString(CultureInfo.InvariantCulture));
+        }
+
+        private static void Append(this StringBuilder sb, string line, NewLineFormat newLine)
+        {
+            switch (newLine)
+            {
+                case NewLineFormat.Auto:
+                    sb.Append(line + Environment.NewLine);
+                    break;
+                case NewLineFormat.Windows:
+                    sb.Append(line + "\r\n");
+                    break;
+                case NewLineFormat.Unix:
+                    sb.Append(line + "\n");
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(newLine), newLine, null);
+            }
         }
     }
 }

--- a/src/App.Metrics.Formatters.Prometheus/Internal/AsciiFormatter.cs
+++ b/src/App.Metrics.Formatters.Prometheus/Internal/AsciiFormatter.cs
@@ -28,11 +28,12 @@ namespace App.Metrics.Formatters.Prometheus.Internal
 
         internal static string Format(IEnumerable<MetricFamily> metrics, NewLineFormat newLine)
         {
+            var newLineChar = GetNewLineChar(newLine);
             var metricFamilys = metrics.ToArray();
             var s = new StringBuilder();
             foreach (var metricFamily in metricFamilys)
             {
-                s.Append(WriteFamily(metricFamily, newLine));
+                s.Append(WriteFamily(metricFamily, newLineChar));
             }
 
             return s.ToString();
@@ -48,7 +49,7 @@ namespace App.Metrics.Formatters.Prometheus.Internal
             }
         }
 
-        private static string WriteFamily(MetricFamily metricFamily, NewLineFormat newLine)
+        private static string WriteFamily(MetricFamily metricFamily, string newLine)
         {
             var s = new StringBuilder();
             s.Append(string.Format("# HELP {0} {1}", metricFamily.name, metricFamily.help), newLine);
@@ -111,7 +112,7 @@ namespace App.Metrics.Formatters.Prometheus.Internal
             }
         }
 
-        private static string WriteMetric(MetricFamily family, Metric metric, NewLineFormat newLine)
+        private static string WriteMetric(MetricFamily family, Metric metric, string newLine)
         {
             var s = new StringBuilder();
             var familyName = family.name;
@@ -181,22 +182,25 @@ namespace App.Metrics.Formatters.Prometheus.Internal
             return string.Format("{0} {1}", WithLabels(family + (namePostfix ?? string.Empty), labels), value.ToString(CultureInfo.InvariantCulture));
         }
 
-        private static void Append(this StringBuilder sb, string line, NewLineFormat newLine)
+        private static string GetNewLineChar(NewLineFormat newLine)
         {
             switch (newLine)
             {
                 case NewLineFormat.Auto:
-                    sb.Append(line + Environment.NewLine);
-                    break;
+                    return Environment.NewLine;
                 case NewLineFormat.Windows:
-                    sb.Append(line + "\r\n");
-                    break;
+                    return "\r\n";
                 case NewLineFormat.Unix:
-                    sb.Append(line + "\n");
-                    break;
+                case NewLineFormat.Default:
+                    return "\n";
                 default:
                     throw new ArgumentOutOfRangeException(nameof(newLine), newLine, null);
             }
+        }
+
+        private static void Append(this StringBuilder sb, string line, string newLineChar)
+        {
+            sb.Append(line + newLineChar);
         }
     }
 }

--- a/src/App.Metrics.Formatters.Prometheus/MetricsPrometheusOptions.cs
+++ b/src/App.Metrics.Formatters.Prometheus/MetricsPrometheusOptions.cs
@@ -18,5 +18,7 @@ namespace App.Metrics.Formatters.Prometheus
         }
 
         public Func<string, string, string> MetricNameFormatter { get; set; }
+
+        public NewLineFormat NewLineFormat { get; set; } = NewLineFormat.Auto;
     }
 }

--- a/src/App.Metrics.Formatters.Prometheus/MetricsPrometheusOptions.cs
+++ b/src/App.Metrics.Formatters.Prometheus/MetricsPrometheusOptions.cs
@@ -19,6 +19,6 @@ namespace App.Metrics.Formatters.Prometheus
 
         public Func<string, string, string> MetricNameFormatter { get; set; }
 
-        public NewLineFormat NewLineFormat { get; set; } = NewLineFormat.Auto;
+        public NewLineFormat NewLineFormat { get; set; } = NewLineFormat.Default;
     }
 }

--- a/src/App.Metrics.Formatters.Prometheus/MetricsPrometheusTextOutputFormatter.cs
+++ b/src/App.Metrics.Formatters.Prometheus/MetricsPrometheusTextOutputFormatter.cs
@@ -38,7 +38,7 @@ namespace App.Metrics.Formatters.Prometheus
 
             using (var streamWriter = new StreamWriter(output))
             {
-                return streamWriter.WriteAsync(AsciiFormatter.Format(metricsData.GetPrometheusMetricsSnapshot(_options.MetricNameFormatter)));
+                return streamWriter.WriteAsync(AsciiFormatter.Format(metricsData.GetPrometheusMetricsSnapshot(_options.MetricNameFormatter), _options.NewLineFormat));
             }
         }
     }

--- a/src/App.Metrics.Formatters.Prometheus/NewLineFormat.cs
+++ b/src/App.Metrics.Formatters.Prometheus/NewLineFormat.cs
@@ -1,0 +1,27 @@
+﻿// <copyright file="NewLineFormat.cs" company="Allan Hardy">
+// Copyright (c) Allan Hardy. All rights reserved.
+// </copyright>
+
+namespace App.Metrics.Formatters.Prometheus
+{
+    /// <summary>
+    /// Line endings format
+    /// </summary>
+    public enum NewLineFormat
+    {
+        /// <summary>
+        /// Use Environement.NewLine as new line character
+        /// </summary>
+        Auto,
+
+        /// <summary>
+        /// Use '\r\n' as new line character
+        /// </summary>
+        Windows,
+
+        /// <summary>
+        /// Use '\r' as new line character
+        /// </summary>
+        Unix
+    }
+}

--- a/src/App.Metrics.Formatters.Prometheus/NewLineFormat.cs
+++ b/src/App.Metrics.Formatters.Prometheus/NewLineFormat.cs
@@ -10,6 +10,11 @@ namespace App.Metrics.Formatters.Prometheus
     public enum NewLineFormat
     {
         /// <summary>
+        /// Use Unix style new line character by default
+        /// </summary>
+        Default,
+
+        /// <summary>
         /// Use Environement.NewLine as new line character
         /// </summary>
         Auto,


### PR DESCRIPTION
…TextOutputFormatter

Thanks for helping out :+1:

Before submitting a pull request, please have a quick read through the [contribution guidlines](https://github.com/alhardy/AppMetrics/blob/master/CONTRIBUTING.md) and provide the following information, where appropriate replace the `[ ]` with a `[X]`

### The issue or feature being addressed

#20 Prometheus reporting returns windows line endings which are not supported by Prometheus scrappers

### Details on the issue fix or feature implementation

- added options to override line end character

### Confirm the following

- [X] I have ensured that I have merged the latest changes from the dev branch
- [X] I have successfully run a [local build](https://github.com/alhardy/AppMetrics#how-to-build)
- [ ] I have included unit tests for the issue/feature
- [X] I have included the github issue number in my commits 