### PR TITLE
fix https://github.com/AppMetrics/AppMetrics/issues/207

### DIFF
--- a/src/App.Metrics.Formatters.Prometheus/Internal/Extensions/MetricValueSourceExtensions.cs
+++ b/src/App.Metrics.Formatters.Prometheus/Internal/Extensions/MetricValueSourceExtensions.cs
@@ -130,7 +130,7 @@ namespace App.Metrics.Formatters.Prometheus.Internal.Extensions
                              {
                                  summary = new Summary
                                            {
-                                               sample_count = (ulong)rescaledVal.Histogram.Count,
+                                               sample_count = (ulong)rescaledVal.Rate.Count,
                                                sample_sum = rescaledVal.Histogram.Sum,
                                                quantile =
                                                {


### PR DESCRIPTION
### The issue or feature being addressed

- https://github.com/AppMetrics/AppMetrics/issues/207

### Details on the issue fix or feature implementation

- Counter for Timer should come from Meter, not Histogram, since Histogram's count would be reseted after an hour.
