### PR TITLE
await writing to output stream before disposing it in MetricsPrometheusTextOutputFormatter, fixes #30

### DIFF
--- a/src/App.Metrics.Formatters.Prometheus/MetricsPrometheusTextOutputFormatter.cs
+++ b/src/App.Metrics.Formatters.Prometheus/MetricsPrometheusTextOutputFormatter.cs
@@ -26,7 +26,7 @@ namespace App.Metrics.Formatters.Prometheus
         public MetricsMediaTypeValue MediaType => new MetricsMediaTypeValue("text", "vnd.appmetrics.metrics.prometheus", "v1", "plain");
 
         /// <inheritdoc/>
-        public Task WriteAsync(
+        public async Task WriteAsync(
             Stream output,
             MetricsDataValueSource metricsData,
             CancellationToken cancellationToken = default(CancellationToken))
@@ -38,7 +38,7 @@ namespace App.Metrics.Formatters.Prometheus
 
             using (var streamWriter = new StreamWriter(output))
             {
-                return streamWriter.WriteAsync(AsciiFormatter.Format(metricsData.GetPrometheusMetricsSnapshot(_options.MetricNameFormatter), _options.NewLineFormat));
+                await streamWriter.WriteAsync(AsciiFormatter.Format(metricsData.GetPrometheusMetricsSnapshot(_options.MetricNameFormatter), _options.NewLineFormat));
             }
         }
     }


### PR DESCRIPTION
### The issue or feature being addressed

This fixes #30.

### Details on the issue fix or feature implementation

We need to await the task that writes to the output stream before exiting the using block, or else it's possible we'll dispose the stream before we finish writing to it. 
 `System.IO.StreamWriter.CheckAsyncTaskInProgress()` can throw an `InvalidOperationException` with the message "The stream is currently in use by a previous operation on the stream." when this happens.