### PR TITLE
change 0.5 quantile from mean to median

### DIFF
--- a/src/App.Metrics.Formatters.Prometheus/Internal/Extensions/MetricValueSourceExtensions.cs
+++ b/src/App.Metrics.Formatters.Prometheus/Internal/Extensions/MetricValueSourceExtensions.cs
@@ -105,7 +105,7 @@ namespace App.Metrics.Formatters.Prometheus.Internal.Extensions
                                                sample_sum = metric.Value.Sum,
                                                quantile =
                                                {
-                                                   new Quantile { quantile = 0.5, value = metric.Value.Mean },
+                                                   new Quantile { quantile = 0.5, value = metric.Value.Median },
                                                    new Quantile { quantile = 0.75, value = metric.Value.Percentile75 },
                                                    new Quantile { quantile = 0.95, value = metric.Value.Percentile95 },
                                                    // new Quantile(){quantile = 0.98, value = metric.Value.Percentile98},
@@ -134,7 +134,7 @@ namespace App.Metrics.Formatters.Prometheus.Internal.Extensions
                                                sample_sum = rescaledVal.Histogram.Sum,
                                                quantile =
                                                {
-                                                   new Quantile { quantile = 0.5, value = rescaledVal.Histogram.Mean },
+                                                   new Quantile { quantile = 0.5, value = rescaledVal.Histogram.Median },
                                                    new Quantile { quantile = 0.75, value = rescaledVal.Histogram.Percentile75 },
                                                    new Quantile { quantile = 0.95, value = rescaledVal.Histogram.Percentile95 },
                                                    // new Quantile(){quantile = 0.98, value = metric.Value.Histogram.Percentile98},


### PR DESCRIPTION
This changes the 0.5 quantile from mean to median.

According to the documentation (https://prometheus.io/docs/practices/histograms/#quantiles) the 0.5 quantile is the median.