### PR TITLE
Lowercase the metric types (fixes #40)

### DIFF
--- a/src/App.Metrics.Formatters.Prometheus/Internal/AsciiFormatter.cs
+++ b/src/App.Metrics.Formatters.Prometheus/Internal/AsciiFormatter.cs
@@ -42,7 +42,7 @@ namespace App.Metrics.Formatters.Prometheus.Internal
         private static void WriteFamily(StreamWriter streamWriter, MetricFamily metricFamily)
         {
             streamWriter.WriteLine("# HELP {0} {1}", metricFamily.name, metricFamily.help);
-            streamWriter.WriteLine("# TYPE {0} {1}", metricFamily.name, metricFamily.type);
+            streamWriter.WriteLine("# TYPE {0} {1}", metricFamily.name, metricFamily.type.ToString().ToLowerInvariant());
             foreach (var metric in metricFamily.metric)
             {
                 WriteMetric(streamWriter, metricFamily, metric);
@@ -53,7 +53,7 @@ namespace App.Metrics.Formatters.Prometheus.Internal
         {
             var s = new StringBuilder();
             s.Append(string.Format("# HELP {0} {1}", metricFamily.name, metricFamily.help), newLine);
-            s.Append(string.Format("# TYPE {0} {1}", metricFamily.name, metricFamily.type), newLine);
+            s.Append(string.Format("# TYPE {0} {1}", metricFamily.name, metricFamily.type.ToString().ToLowerInvariant()), newLine);
             foreach (var metric in metricFamily.metric)
             {
                 s.Append(WriteMetric(metricFamily, metric, newLine), newLine);


### PR DESCRIPTION
### The issue or feature being addressed

- https://github.com/AppMetrics/Prometheus/issues/40

### Details on the issue fix or feature implementation

- Prometheus 2.4.0 has started validating that metric type names are lowercase. [If they're not, the scrape will fail](https://github.com/prometheus/prometheus/issues/4602). The PR ensures that `# TYPE` statements always use the lowercase version of the metric type.

### Confirm the following

- [ X] I have ensured that I have merged the latest changes from the dev branch
- [ X] I have successfully run a [local build](https://github.com/alhardy/AppMetrics#how-to-build)
- [  ] I have included unit tests for the issue/feature
- [X ] I have included the github issue number in my commits 