### PR TITLE
#44 fix: Use ResetOnReport when generated report for Prometheus

### DIFF
--- a/src/App.Metrics.Formatters.Prometheus/Internal/Extensions/MetricValueSourceExtensions.cs
+++ b/src/App.Metrics.Formatters.Prometheus/Internal/Extensions/MetricValueSourceExtensions.cs
@@ -57,7 +57,7 @@ namespace App.Metrics.Formatters.Prometheus.Internal.Extensions
                              {
                                  gauge = new Gauge
                                          {
-                                             value = metric.Value.Count
+                                            value = metric.ValueProvider.GetValue(metric.ResetOnReporting).Count
                                          },
                                  label = metric.Tags.ToLabelPairs()
                              }

--- a/src/App.Metrics.Formatters.Prometheus/Internal/Extensions/MetricValueSourceExtensions.cs
+++ b/src/App.Metrics.Formatters.Prometheus/Internal/Extensions/MetricValueSourceExtensions.cs
@@ -51,6 +51,14 @@ namespace App.Metrics.Formatters.Prometheus.Internal.Extensions
 
         public static IEnumerable<Metric> ToPrometheusMetrics(this CounterValueSource metric)
         {
+            IEnumerable<Metric> items = null;
+
+            // when We Resting counter, we lost Items "Count"
+            if (metric.Value.Items?.Length > 0)
+            {
+                items = metric.Value.Items.Select(i => i.ToPrometheusMetric());
+            }
+
             var result = new List<Metric>
                          {
                              new Metric
@@ -63,9 +71,9 @@ namespace App.Metrics.Formatters.Prometheus.Internal.Extensions
                              }
                          };
 
-            if (metric.Value.Items?.Length > 0)
+            if (metric.Value.Items?.Length > 0 && items != null)
             {
-                result.AddRange(metric.Value.Items.Select(i => i.ToPrometheusMetric()));
+                result.AddRange(items);
             }
 
             return result;


### PR DESCRIPTION
Thanks for helping out :+1:

Before submitting a pull request, please have a quick read through the [contribution guidlines](https://github.com/alhardy/AppMetrics/blob/master/CONTRIBUTING.md) and provide the following information, where appropriate replace the `[ ]` with a `[X]`

### The issue or feature being addressed

- https://github.com/AppMetrics/Prometheus/issues/44


### Details on the issue fix or feature implementation

- fix :Use ResetOnReport when generated report for Prometheus


### Confirm the following

- [x] I have ensured that I have merged the latest changes from the dev branch
- [x] I have successfully run a [local build](https://github.com/alhardy/AppMetrics#how-to-build)
- [x] I have included unit tests for the issue/feature
- [x] I have included the github issue number in my commits 