### PR TITLE
add prometheus push gateway reporter

### DIFF
--- a/src/App.Metrics.Formatters.Prometheus/MetricsPrometheusPushGatewayReporter.cs
+++ b/src/App.Metrics.Formatters.Prometheus/MetricsPrometheusPushGatewayReporter.cs
@@ -1,0 +1,91 @@
+﻿// <copyright file="MetricsPrometheusPushGatewayReporter.cs" company="App Metrics Contributors">
+// Copyright (c) App Metrics Contributors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using App.Metrics.Filters;
+using App.Metrics.Internal.NoOp;
+using App.Metrics.Reporting;
+
+namespace App.Metrics.Formatters.Prometheus
+{
+    public class MetricsPrometheusPushGatewayReporter : IReportMetrics
+    {
+        private static readonly HttpClient _httpClient = new HttpClient { Timeout = TimeSpan.FromSeconds(10) };
+
+        public IFilterMetrics Filter { get; set; }
+
+        public TimeSpan FlushInterval { get; set; }
+
+        public IMetricsOutputFormatter Formatter { get; set; }
+
+        private readonly Uri _targetUrl;
+
+        public MetricsPrometheusPushGatewayReporter(MetricsPrometheusPushGatewayReporterSettings settings)
+        {
+            settings = settings ?? throw new ArgumentNullException(nameof(settings));
+
+            if (string.IsNullOrEmpty(settings.Endpoint))
+            {
+                throw new ArgumentNullException(nameof(settings.Endpoint));
+            }
+
+            if (string.IsNullOrEmpty(settings.Job))
+            {
+                throw new ArgumentNullException(nameof(settings.Job));
+            }
+
+            var sb = new StringBuilder($"{settings.Endpoint.TrimEnd('/')}/metrics/job/{settings.Job}");
+
+            if (!string.IsNullOrEmpty(settings.Instance))
+            {
+                sb.AppendFormat("/instance/{0}", settings.Instance);
+            }
+
+            if (settings.AdditionalLabels != null)
+            {
+                foreach (var label in settings.AdditionalLabels.Where(x => !string.IsNullOrWhiteSpace(x.Key) && !string.IsNullOrWhiteSpace(x.Value)))
+                {
+                    sb.AppendFormat("/{0}/{1}", label.Key, label.Value);
+                }
+            }
+
+            if (!Uri.TryCreate(sb.ToString(), UriKind.Absolute, out _targetUrl))
+            {
+                throw new ArgumentException("Endpoint must be a valid url", nameof(settings.Endpoint));
+            }
+
+            Formatter = new MetricsPrometheusTextOutputFormatter();
+            FlushInterval = TimeSpan.FromSeconds(20);
+            Filter = new NullMetricsFilter();
+        }
+
+        public async Task<bool> FlushAsync(MetricsDataValueSource metricsData, CancellationToken cancellationToken)
+        {
+            var request = new HttpRequestMessage(HttpMethod.Put, _targetUrl);
+            request.Content = BuildStreamContent(metricsData, cancellationToken);
+
+            var response = await _httpClient.SendAsync(request, cancellationToken);
+
+            return response.IsSuccessStatusCode;
+        }
+
+        private HttpContent BuildStreamContent(MetricsDataValueSource metrics, CancellationToken cancellationToken)
+        {
+            var memoryStream = new MemoryStream();
+            Formatter.WriteAsync(memoryStream, metrics, cancellationToken);
+
+            var content = new ByteArrayContent(memoryStream.ToArray());
+            content.Headers.ContentType = new MediaTypeHeaderValue(Formatter.MediaType.ContentType);
+
+            return content;
+        }
+    }
+}

--- a/src/App.Metrics.Formatters.Prometheus/MetricsPrometheusPushGatewayReporterSettings.cs
+++ b/src/App.Metrics.Formatters.Prometheus/MetricsPrometheusPushGatewayReporterSettings.cs
@@ -1,0 +1,19 @@
+﻿// <copyright file="MetricsPrometheusPushGatewayReporterSettings.cs" company="App Metrics Contributors">
+// Copyright (c) App Metrics Contributors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+
+namespace App.Metrics.Formatters.Prometheus
+{
+    public class MetricsPrometheusPushGatewayReporterSettings
+    {
+        public string Endpoint { get; set; }
+
+        public string Job { get; set; }
+
+        public string Instance { get; set; }
+
+        public IEnumerable<KeyValuePair<string, string>> AdditionalLabels { get; set; }
+    }
+}


### PR DESCRIPTION
This addresses #18.

This is what I've been using for a while to push metrics to a push gateway. I figured I may as well contribute it, but it may not be a good fit here.

.NET Standard 1.6 has `System.Net.Http`, but .NET Framework 4.5.2 does not. This uses `HttpClient` which is in `System.Net.Http`. Since App.Metrics.Formatters.Prometheus library targets both, this PR won't build for 4.5.2. I could add that package so that it builds for 4.5.2, but that introduces another dependency for the project.

Alternatively it could go into a completely separate App.Metrics.Formatters.Prometheus.PushGateway or something like that, but I don't know if that's worth the trouble for only this.